### PR TITLE
Add mesearcher.com as additional production domain

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -12,6 +12,10 @@ command = "npm run build:frontend"
 pattern = "mesearch.emilycogsdill.com"
 custom_domain = true
 
+[[routes]]
+pattern = "mesearcher.com"
+custom_domain = true
+
 [assets]
 directory = "./dist"
 binding = "ASSETS"


### PR DESCRIPTION
- Add mesearcher.com route with custom_domain in wrangler.toml
- Update UserMenu to recognize mesearcher.com as production host