### PR TITLE
Implement Short Dark Triad (SD3) assessment

### DIFF
--- a/e2e/sd3.spec.ts
+++ b/e2e/sd3.spec.ts
@@ -1,0 +1,140 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Short Dark Triad (SD3) Assessment', () => {
+  test.beforeEach(async ({ page }) => {
+    // Clear localStorage before each test
+    await page.goto('/');
+    await page.evaluate(() => localStorage.clear());
+  });
+
+  test('complete assessment and see 3 traits in results', async ({ page }) => {
+    // Navigate to SD3 assessment
+    await page.goto('/test/sd3');
+
+    // Verify intro page
+    await expect(page.getByText('Short Dark Triad (SD3)')).toBeVisible();
+    await expect(page.getByText('Jones & Paulhus (2014)')).toBeVisible();
+
+    // Verify important context disclaimer is shown
+    await expect(page.getByText('Important Context')).toBeVisible();
+    await expect(page.getByText('normal personality variation')).toBeVisible();
+
+    // Start the assessment
+    await page.getByRole('button', { name: /Begin Assessment/i }).click();
+
+    // Answer all 27 questions with "Agree" (value 4)
+    for (let i = 1; i <= 27; i++) {
+      // Verify we're on question i
+      await expect(page.getByTestId('sd3-progress')).toHaveText(`${i} of 27`);
+
+      // Click the 4th option (Agree) using testid
+      await page.getByTestId('sd3-option-4').click();
+    }
+
+    // Should see completion screen
+    await expect(page.getByText('Assessment Complete')).toBeVisible();
+
+    // Click to view results
+    await page.getByRole('button', { name: /View Results/i }).click();
+
+    // Verify we're on the results page
+    await expect(page).toHaveURL('/test/sd3/results');
+
+    // Verify all 3 traits are displayed
+    await expect(page.getByText('Machiavellianism').first()).toBeVisible();
+    await expect(page.getByText('Narcissism').first()).toBeVisible();
+    await expect(page.getByText('Psychopathy').first()).toBeVisible();
+
+    // Verify results title is shown
+    await expect(page.getByText('Short Dark Triad Profile')).toBeVisible();
+    await expect(page.getByText('Your Results', { exact: true })).toBeVisible();
+
+    // Verify critical framing disclaimer is shown in results
+    await expect(page.getByText('Understanding Your Results')).toBeVisible();
+    await expect(page.getByText('subclinical personality traits, not disorders')).toBeVisible();
+
+    // Verify citation is shown
+    await expect(
+      page.getByText('Jones, D.N., & Paulhus, D.L. (2014)')
+    ).toBeVisible();
+  });
+
+  test('can resume progress after navigating away', async ({ page }) => {
+    // Start assessment
+    await page.goto('/test/sd3');
+    await page.getByRole('button', { name: /Begin Assessment/i }).click();
+
+    // Answer first 5 questions using testid
+    for (let i = 0; i < 5; i++) {
+      await page.getByTestId('sd3-option-4').click();
+    }
+
+    // Verify we're on question 6
+    await expect(page.getByTestId('sd3-progress')).toHaveText('6 of 27');
+
+    // Navigate away
+    await page.goto('/');
+
+    // Return to assessment
+    await page.goto('/test/sd3');
+
+    // Should see Resume Progress button
+    await expect(page.getByRole('button', { name: /Resume Progress/i })).toBeVisible();
+
+    // Resume progress
+    await page.getByRole('button', { name: /Resume Progress/i }).click();
+
+    // Should be on question 6
+    await expect(page.getByTestId('sd3-progress')).toHaveText('6 of 27');
+  });
+
+  test('SD3 test card is visible on home page', async ({ page }) => {
+    await page.goto('/');
+
+    // Verify the SD3 test card is displayed
+    await expect(page.getByRole('heading', { name: 'Dark Triad' })).toBeVisible();
+    await expect(page.getByText('SD3')).toBeVisible();
+    await expect(page.getByText('5 min')).toBeVisible();
+    await expect(page.getByText('Machiavellianism, Narcissism, and Psychopathy')).toBeVisible();
+  });
+
+  test('can navigate to SD3 from home page', async ({ page }) => {
+    await page.goto('/');
+
+    // Find the SD3 test card and click "Begin Assessment"
+    // The card contains "Dark Triad" heading and has a Begin Assessment link
+    const sd3Card = page.locator('.card-premium', { has: page.getByRole('heading', { name: 'Dark Triad' }) });
+    await sd3Card.getByRole('link', { name: /Begin Assessment/i }).click();
+
+    // Should be on SD3 assessment page
+    await expect(page).toHaveURL('/test/sd3');
+    await expect(page.getByText('Short Dark Triad (SD3)')).toBeVisible();
+  });
+
+  test('shows no results page when accessing results without completing test', async ({ page }) => {
+    // Go directly to results page without completing test
+    await page.goto('/test/sd3/results');
+
+    // Should see "No Results Found" message
+    await expect(page.getByText('No Results Found')).toBeVisible();
+    await expect(page.getByRole('button', { name: /Take the Test/i })).toBeVisible();
+  });
+
+  test('displays trait level indicators in results', async ({ page }) => {
+    // Complete the assessment first
+    await page.goto('/test/sd3');
+    await page.getByRole('button', { name: /Begin Assessment/i }).click();
+
+    // Answer all 27 questions using testid
+    for (let i = 1; i <= 27; i++) {
+      await page.getByTestId('sd3-option-4').click();
+    }
+
+    await page.getByRole('button', { name: /View Results/i }).click();
+
+    // Verify level indicators are shown (Low/Average/High)
+    // At least one level should be visible
+    const levelIndicators = page.locator('span', { hasText: /^(Low|Average|High)$/ });
+    await expect(levelIndicators.first()).toBeVisible();
+  });
+});

--- a/e2e/sd3.spec.ts
+++ b/e2e/sd3.spec.ts
@@ -94,7 +94,7 @@ test.describe('Short Dark Triad (SD3) Assessment', () => {
     // Verify the SD3 test card is displayed
     await expect(page.getByRole('heading', { name: 'Dark Triad' })).toBeVisible();
     await expect(page.getByText('SD3')).toBeVisible();
-    await expect(page.getByText('5 min')).toBeVisible();
+    await expect(page.getByText('5 min', { exact: true })).toBeVisible();
     await expect(page.getByText('Machiavellianism, Narcissism, and Psychopathy')).toBeVisible();
   });
 

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -5,6 +5,8 @@ import HexacoResults from './components/HexacoResults';
 import { HexacoResponse, calculateScores, DimensionScore } from './data/hexaco-scoring';
 import BigFiveAssessment from './components/BigFiveAssessment';
 import BigFiveResults from './components/BigFiveResults';
+import SD3Assessment from './components/SD3Assessment';
+import SD3Results from './components/SD3Results';
 import { enneagramItems, likertScale, type LikertValue } from './data/enneagram-items';
 import { calculateEnneagramResult, type EnneagramResult } from './data/enneagram-scoring';
 import { EnneagramResults } from './components/EnneagramResults';
@@ -217,6 +219,16 @@ function HomePage() {
               description="Explore your core motivations through nine distinct personality archetypes. Renowned for personal growth insights."
               time="10 min"
               seriousness={2}
+              fun={5}
+            />
+            <TestCard
+              title="Dark Triad"
+              subtitle="SD3"
+              slug="sd3"
+              keywords={['Strategy', 'Confidence', 'Boldness']}
+              description="Measures subclinical Machiavellianism, Narcissism, and Psychopathy. High engagement due to 'forbidden' appeal."
+              time="5 min"
+              seriousness={4}
               fun={5}
             />
           </div>
@@ -668,6 +680,8 @@ export default function App() {
             <Route path="/my-results" element={<ResultsHistory />} />
             <Route path="/test/big-five" element={<BigFiveAssessment />} />
             <Route path="/test/big-five/results" element={<BigFiveResults />} />
+            <Route path="/test/sd3" element={<SD3Assessment />} />
+            <Route path="/test/sd3/results" element={<SD3Results />} />
             <Route path="/test/:slug" element={<TestRouter />} />
             <Route
               path="/hexaco"

--- a/frontend/components/SD3Assessment.tsx
+++ b/frontend/components/SD3Assessment.tsx
@@ -1,0 +1,391 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { items, shuffleItems, type Item } from '../data/sd3-items';
+import {
+  type Response,
+  calculateAllScores,
+  serializeResponses,
+  deserializeResponses,
+  serializeResults,
+} from '../data/sd3-scoring';
+import { useAuth } from '../contexts/AuthContext';
+
+const STORAGE_KEY = 'mesearch-sd3-responses';
+const RESULTS_STORAGE_KEY = 'mesearch-sd3-results';
+
+type AssessmentPhase = 'intro' | 'assessment' | 'complete';
+
+const likertOptions = [
+  { value: 1, label: 'Strongly Disagree' },
+  { value: 2, label: 'Disagree' },
+  { value: 3, label: 'Neither Agree Nor Disagree' },
+  { value: 4, label: 'Agree' },
+  { value: 5, label: 'Strongly Agree' },
+];
+
+export default function SD3Assessment() {
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const [phase, setPhase] = useState<AssessmentPhase>('intro');
+  const [shuffledItems, setShuffledItems] = useState<Item[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [responses, setResponses] = useState<Response[]>([]);
+  const [hasSavedProgress, setHasSavedProgress] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
+
+  // Initialize shuffled items and check for saved progress
+  useEffect(() => {
+    const shuffled = shuffleItems(42); // Use consistent seed
+    setShuffledItems(shuffled);
+
+    // Check for saved progress
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved) {
+      const savedResponses = deserializeResponses(saved);
+      if (savedResponses && savedResponses.length > 0) {
+        setHasSavedProgress(true);
+      }
+    }
+  }, []);
+
+  // Resume saved progress
+  const resumeProgress = useCallback(() => {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved) {
+      const savedResponses = deserializeResponses(saved);
+      if (savedResponses) {
+        setResponses(savedResponses);
+        setCurrentIndex(savedResponses.length);
+        setPhase('assessment');
+      }
+    }
+  }, []);
+
+  // Start fresh assessment
+  const startFresh = useCallback(() => {
+    localStorage.removeItem(STORAGE_KEY);
+    setResponses([]);
+    setCurrentIndex(0);
+    setPhase('assessment');
+  }, []);
+
+  // Save progress to localStorage
+  const saveProgress = useCallback((newResponses: Response[]) => {
+    localStorage.setItem(STORAGE_KEY, serializeResponses(newResponses));
+  }, []);
+
+  // Save results to backend if user is logged in
+  const saveResultsToBackend = useCallback(
+    async (results: ReturnType<typeof calculateAllScores>) => {
+      if (!user) return;
+
+      setSaveStatus('saving');
+      try {
+        const res = await fetch('/api/results', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({
+            test_type: 'sd3',
+            scores: results,
+          }),
+        });
+
+        if (res.ok) {
+          setSaveStatus('saved');
+        } else {
+          setSaveStatus('error');
+        }
+      } catch {
+        setSaveStatus('error');
+      }
+    },
+    [user]
+  );
+
+  // Handle response selection
+  const handleResponse = useCallback(
+    (value: number) => {
+      const currentItem = shuffledItems[currentIndex];
+      if (!currentItem) return;
+
+      const newResponse: Response = {
+        itemId: currentItem.id,
+        value,
+      };
+
+      const newResponses = [...responses, newResponse];
+      setResponses(newResponses);
+      saveProgress(newResponses);
+
+      // Check if assessment is complete
+      if (currentIndex + 1 >= shuffledItems.length) {
+        // Calculate and save results
+        const results = calculateAllScores(newResponses);
+        localStorage.setItem(RESULTS_STORAGE_KEY, serializeResults(results));
+        localStorage.removeItem(STORAGE_KEY); // Clear in-progress data
+        setPhase('complete');
+        // Auto-save to backend if logged in
+        saveResultsToBackend(results);
+      } else {
+        setCurrentIndex(currentIndex + 1);
+      }
+    },
+    [currentIndex, shuffledItems, responses, saveProgress, saveResultsToBackend]
+  );
+
+  // Go back to previous question
+  const handleBack = useCallback(() => {
+    if (currentIndex > 0) {
+      const newResponses = responses.slice(0, -1);
+      setResponses(newResponses);
+      saveProgress(newResponses);
+      setCurrentIndex(currentIndex - 1);
+    }
+  }, [currentIndex, responses, saveProgress]);
+
+  // Render intro phase
+  if (phase === 'intro') {
+    return (
+      <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
+        <Header />
+        <main className="mx-auto max-w-2xl px-6 py-16">
+          <div className="card-premium rounded-lg p-10">
+            <div className="text-center mb-8">
+              <span className="inline-block px-3 py-1 rounded-full bg-indigo-500/20 border border-indigo-500/30 text-indigo-400 text-xs tracking-wide uppercase mb-4">
+                Research-Backed
+              </span>
+              <p className="text-[var(--color-champagne)] text-xs tracking-[0.3em] uppercase mb-4">
+                Assessment
+              </p>
+              <h2 className="font-display text-3xl font-medium text-[var(--color-text-primary)] mb-2 transition-colors duration-300">
+                Short Dark Triad (SD3)
+              </h2>
+              <p className="text-[var(--color-text-muted)] text-sm">
+                Jones & Paulhus (2014)
+              </p>
+            </div>
+
+            <div className="space-y-6 text-[var(--color-text-secondary)] text-sm leading-relaxed">
+              <p>
+                This assessment measures three personality traits:
+                <strong className="text-[var(--color-text-primary)]"> Machiavellianism</strong>,
+                <strong className="text-[var(--color-text-primary)]"> Narcissism</strong>, and
+                <strong className="text-[var(--color-text-primary)]"> Psychopathy</strong>.
+              </p>
+
+              {/* Important framing disclaimer */}
+              <div className="bg-amber-500/10 border border-amber-500/30 rounded-lg p-4 text-amber-200">
+                <p className="font-medium mb-2">Important Context</p>
+                <p className="text-sm text-amber-200/80">
+                  This measures <strong>normal personality variation</strong>, not clinical
+                  disorders. Everyone has some degree of these traits. The &quot;Dark Triad&quot; label
+                  reflects that these traits can lead to socially undesirable behaviors at extreme
+                  levels, but at moderate levels they can also be adaptive (e.g., leadership,
+                  confidence, resilience).
+                </p>
+              </div>
+
+              <div className="bg-[var(--color-bg-secondary)] rounded-lg p-6 space-y-4">
+                <h3 className="text-[var(--color-text-primary)] font-medium">
+                  Before you begin:
+                </h3>
+                <ul className="list-disc list-inside space-y-2 text-[var(--color-text-muted)]">
+                  <li>This test contains 27 questions</li>
+                  <li>It takes approximately 5 minutes to complete</li>
+                  <li>Your progress is automatically saved</li>
+                  <li>Answer honestly for the most accurate results</li>
+                  <li>There are no right or wrong answers</li>
+                </ul>
+              </div>
+
+              <p className="text-[var(--color-text-muted)] text-xs">
+                For each statement, indicate how much you agree or disagree on a scale from
+                &quot;Strongly Disagree&quot; to &quot;Strongly Agree.&quot;
+              </p>
+            </div>
+
+            <div className="mt-10 space-y-4">
+              {hasSavedProgress ? (
+                <>
+                  <button
+                    onClick={resumeProgress}
+                    className="btn-gold w-full py-4 rounded text-sm tracking-widest uppercase"
+                  >
+                    Resume Progress
+                  </button>
+                  <button
+                    onClick={startFresh}
+                    className="btn-ghost w-full py-4 rounded text-sm tracking-widest uppercase"
+                  >
+                    Start Over
+                  </button>
+                </>
+              ) : (
+                <button
+                  onClick={startFresh}
+                  className="btn-gold w-full py-4 rounded text-sm tracking-widest uppercase"
+                  data-testid="sd3-start"
+                >
+                  Begin Assessment
+                </button>
+              )}
+            </div>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  // Render completion phase
+  if (phase === 'complete') {
+    return (
+      <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
+        <Header />
+        <main className="mx-auto max-w-2xl px-6 py-16">
+          <div className="card-premium rounded-lg p-10 text-center">
+            <div className="w-16 h-16 mx-auto mb-6 rounded-full border-2 border-[var(--color-champagne)] flex items-center justify-center">
+              <svg
+                className="w-8 h-8 text-[var(--color-champagne)]"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M5 13l4 4L19 7"
+                />
+              </svg>
+            </div>
+            <p className="text-[var(--color-champagne)] text-xs tracking-[0.3em] uppercase mb-4">
+              Complete
+            </p>
+            <h2 className="font-display text-3xl font-medium text-[var(--color-text-primary)] mb-4 transition-colors duration-300">
+              Assessment Complete
+            </h2>
+            <p className="text-[var(--color-text-secondary)] mb-8">
+              Thank you for completing the Short Dark Triad assessment. Your results are ready.
+            </p>
+            <button
+              onClick={() => navigate('/test/sd3/results')}
+              className="btn-gold px-10 py-4 rounded text-sm tracking-widest uppercase"
+              data-testid="sd3-view-results"
+            >
+              View Results
+            </button>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  // Render assessment phase
+  const currentItem = shuffledItems[currentIndex];
+  const progress = ((currentIndex + 1) / shuffledItems.length) * 100;
+
+  return (
+    <div className="min-h-screen bg-[var(--color-bg-primary)] flex flex-col transition-colors duration-300">
+      {/* Progress Header */}
+      <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
+        <div className="mx-auto max-w-3xl px-6 py-4">
+          <div className="flex items-center justify-between mb-3">
+            <Link
+              to="/"
+              className="font-display text-lg font-semibold tracking-wide text-gold-gradient"
+            >
+              Mesearch
+            </Link>
+            <span className="text-[var(--color-text-muted)] text-sm" data-testid="sd3-progress">
+              {currentIndex + 1} of {shuffledItems.length}
+            </span>
+          </div>
+          {/* Progress bar */}
+          <div className="h-1 bg-[var(--color-border)] rounded-full overflow-hidden">
+            <div
+              className="h-full bg-gradient-to-r from-[var(--color-champagne)] to-[var(--color-gold)] transition-all duration-300 ease-out"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+        </div>
+      </header>
+
+      {/* Question */}
+      <main className="flex-1 flex items-center justify-center px-6 py-12">
+        <div className="w-full max-w-xl">
+          <div className="text-center mb-12">
+            <p className="text-[var(--color-text-primary)] text-xl md:text-2xl leading-relaxed font-light transition-colors duration-300">
+              {currentItem?.text}
+            </p>
+          </div>
+
+          {/* Likert Scale */}
+          <div className="space-y-3">
+            {likertOptions.map((option) => (
+              <button
+                key={option.value}
+                onClick={() => handleResponse(option.value)}
+                className="w-full group"
+                data-testid={`sd3-option-${option.value}`}
+              >
+                <div className="flex items-center gap-4 p-4 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-secondary)] hover:border-[var(--color-champagne)]/50 hover:bg-[var(--color-bg-secondary)]/80 transition-all duration-200">
+                  <div className="w-8 h-8 rounded-full border-2 border-[var(--color-border)] group-hover:border-[var(--color-champagne)] flex items-center justify-center transition-colors duration-200">
+                    <span className="text-[var(--color-text-muted)] group-hover:text-[var(--color-champagne)] text-sm font-medium transition-colors duration-200">
+                      {option.value}
+                    </span>
+                  </div>
+                  <span className="text-[var(--color-text-secondary)] group-hover:text-[var(--color-text-primary)] transition-colors duration-200">
+                    {option.label}
+                  </span>
+                </div>
+              </button>
+            ))}
+          </div>
+
+          {/* Back button */}
+          {currentIndex > 0 && (
+            <div className="mt-8 text-center">
+              <button
+                onClick={handleBack}
+                className="text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] text-sm transition-colors duration-200"
+              >
+                &larr; Previous Question
+              </button>
+            </div>
+          )}
+        </div>
+      </main>
+
+      {/* Footer */}
+      <footer className="border-t border-[var(--color-border-subtle)] py-4 transition-colors duration-300">
+        <div className="mx-auto max-w-3xl px-6 flex justify-between items-center">
+          <p className="text-[var(--color-text-muted)] text-xs">
+            Your progress is automatically saved
+          </p>
+          <Link
+            to="/"
+            className="text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] text-xs transition-colors duration-200"
+          >
+            Save & Exit
+          </Link>
+        </div>
+      </footer>
+    </div>
+  );
+}
+
+function Header() {
+  return (
+    <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
+      <div className="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
+        <Link
+          to="/"
+          className="font-display text-2xl font-semibold tracking-wide text-gold-gradient"
+        >
+          Mesearch
+        </Link>
+      </div>
+    </header>
+  );
+}

--- a/frontend/components/SD3Results.tsx
+++ b/frontend/components/SD3Results.tsx
@@ -1,0 +1,434 @@
+import { useState, useEffect, useMemo } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import {
+  type SD3Results as Results,
+  type TraitScore,
+  deserializeResults,
+  getPercentileInterpretation,
+  getTraitDescription,
+} from '../data/sd3-scoring';
+import { traitInfo, type DarkTrait } from '../data/sd3-items';
+
+const RESULTS_STORAGE_KEY = 'mesearch-sd3-results';
+
+export default function SD3Results() {
+  const navigate = useNavigate();
+  const [results, setResults] = useState<Results | null>(null);
+  const [expandedTrait, setExpandedTrait] = useState<DarkTrait | null>(null);
+
+  useEffect(() => {
+    const saved = localStorage.getItem(RESULTS_STORAGE_KEY);
+    if (saved) {
+      const parsed = deserializeResults(saved);
+      setResults(parsed);
+    }
+  }, []);
+
+  if (!results) {
+    return (
+      <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
+        <Header />
+        <main className="mx-auto max-w-2xl px-6 py-16 text-center">
+          <div className="card-premium rounded-lg p-10">
+            <h2 className="font-display text-2xl font-medium text-[var(--color-text-primary)] mb-4">
+              No Results Found
+            </h2>
+            <p className="text-[var(--color-text-secondary)] mb-8">
+              You haven&apos;t completed the Short Dark Triad assessment yet.
+            </p>
+            <button
+              onClick={() => navigate('/test/sd3')}
+              className="btn-gold px-8 py-3 rounded text-sm tracking-widest uppercase"
+            >
+              Take the Test
+            </button>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  const traitScores = results.traits;
+
+  return (
+    <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
+      <Header />
+      <main className="mx-auto max-w-4xl px-6 py-12">
+        {/* Title */}
+        <div className="text-center mb-12">
+          <p className="text-[var(--color-champagne)] text-xs tracking-[0.3em] uppercase mb-4">
+            Your Results
+          </p>
+          <h2 className="font-display text-4xl font-medium text-[var(--color-text-primary)] mb-2 transition-colors duration-300">
+            Short Dark Triad Profile
+          </h2>
+          <p className="text-[var(--color-text-muted)] text-sm">
+            Completed {new Date(results.completedAt).toLocaleDateString()}
+          </p>
+        </div>
+
+        {/* Critical Framing Disclaimer */}
+        <div className="card-premium rounded-lg p-6 mb-8 bg-amber-500/5 border border-amber-500/20">
+          <div className="flex items-start gap-4">
+            <div className="flex-shrink-0 w-10 h-10 rounded-full bg-amber-500/20 flex items-center justify-center">
+              <svg
+                className="w-5 h-5 text-amber-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+            </div>
+            <div>
+              <h3 className="text-amber-300 font-medium mb-2">
+                Understanding Your Results
+              </h3>
+              <div className="text-amber-200/70 text-sm space-y-2">
+                <p>
+                  <strong>These are subclinical personality traits, not disorders.</strong> The
+                  &quot;Dark Triad&quot; measures normal personality variation that exists in everyone
+                  to varying degrees.
+                </p>
+                <p>
+                  Higher scores do not indicate a problem or diagnosis. At moderate levels, these
+                  traits can be adaptive (e.g., strategic thinking, confidence, boldness).
+                </p>
+                <p>
+                  This assessment cannot diagnose Narcissistic Personality Disorder, Antisocial
+                  Personality Disorder, or any other clinical condition.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Triangle Chart */}
+        <div className="card-premium rounded-lg p-8 mb-8">
+          <h3 className="text-center text-[var(--color-text-secondary)] text-sm uppercase tracking-wider mb-6">
+            Trait Overview
+          </h3>
+          <div className="flex justify-center">
+            <TriangleChart scores={traitScores} />
+          </div>
+        </div>
+
+        {/* Trait Breakdown */}
+        <div className="space-y-4" data-testid="sd3-results">
+          {traitScores.map((score) => (
+            <TraitCard
+              key={score.trait}
+              score={score}
+              isExpanded={expandedTrait === score.trait}
+              onToggle={() =>
+                setExpandedTrait(expandedTrait === score.trait ? null : score.trait)
+              }
+            />
+          ))}
+        </div>
+
+        {/* Actions */}
+        <div className="mt-12 flex flex-col sm:flex-row gap-4 justify-center">
+          <button
+            onClick={() => navigate('/test/sd3')}
+            className="btn-ghost px-8 py-3 rounded text-sm tracking-widest uppercase"
+          >
+            Retake Test
+          </button>
+          <Link
+            to="/"
+            className="btn-gold px-8 py-3 rounded text-sm tracking-widest uppercase text-center"
+          >
+            Explore More Tests
+          </Link>
+        </div>
+
+        {/* Citation */}
+        <div className="mt-12 text-center">
+          <p className="text-[var(--color-text-muted)] text-xs leading-relaxed max-w-2xl mx-auto mb-4">
+            This assessment is based on self-reported responses and measures subclinical
+            personality traits. Results should be used for self-reflection and personal insight,
+            not as clinical diagnoses or labels.
+          </p>
+          <p className="text-[var(--color-text-muted)] text-xs italic">
+            Citation: Jones, D.N., & Paulhus, D.L. (2014). Introducing the Short Dark Triad (SD3):
+            A Brief Measure of Dark Personality Traits. <em>Assessment</em>, 21(1), 28-41.
+          </p>
+        </div>
+      </main>
+    </div>
+  );
+}
+
+function Header() {
+  return (
+    <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
+      <div className="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
+        <Link
+          to="/"
+          className="font-display text-2xl font-semibold tracking-wide text-gold-gradient"
+        >
+          Mesearch
+        </Link>
+      </div>
+    </header>
+  );
+}
+
+interface TriangleChartProps {
+  scores: TraitScore[];
+}
+
+function TriangleChart({ scores }: TriangleChartProps) {
+  const size = 300;
+  const center = size / 2;
+  const maxRadius = size / 2 - 50;
+  const levels = 5;
+
+  // Order traits for the triangle: M, N, P (clockwise from top)
+  const orderedTraits: DarkTrait[] = ['machiavellianism', 'narcissism', 'psychopathy'];
+  const orderedScores = useMemo(() => {
+    return orderedTraits.map((t) => scores.find((s) => s.trait === t)!);
+  }, [scores]);
+
+  // Calculate points for the triangle
+  const angleStep = (2 * Math.PI) / orderedTraits.length;
+  const startAngle = -Math.PI / 2; // Start from top
+
+  const getPoint = (index: number, value: number) => {
+    const angle = startAngle + index * angleStep;
+    const radius = (value / 5) * maxRadius; // Assuming max score is 5
+    return {
+      x: center + radius * Math.cos(angle),
+      y: center + radius * Math.sin(angle),
+    };
+  };
+
+  // Generate polygon points for the score shape
+  const polygonPoints = orderedScores
+    .map((score, i) => {
+      const point = getPoint(i, score.meanScore);
+      return `${point.x},${point.y}`;
+    })
+    .join(' ');
+
+  return (
+    <svg width={size} height={size} className="overflow-visible">
+      {/* Background triangles (levels) */}
+      {Array.from({ length: levels }).map((_, levelIndex) => {
+        const levelRadius = ((levelIndex + 1) / levels) * maxRadius;
+        const points = orderedTraits
+          .map((_, i) => {
+            const angle = startAngle + i * angleStep;
+            const x = center + levelRadius * Math.cos(angle);
+            const y = center + levelRadius * Math.sin(angle);
+            return `${x},${y}`;
+          })
+          .join(' ');
+
+        return (
+          <polygon
+            key={levelIndex}
+            points={points}
+            fill="none"
+            stroke="var(--color-border)"
+            strokeWidth={1}
+            opacity={0.5}
+          />
+        );
+      })}
+
+      {/* Axis lines */}
+      {orderedTraits.map((_, i) => {
+        const angle = startAngle + i * angleStep;
+        const x2 = center + maxRadius * Math.cos(angle);
+        const y2 = center + maxRadius * Math.sin(angle);
+        return (
+          <line
+            key={i}
+            x1={center}
+            y1={center}
+            x2={x2}
+            y2={y2}
+            stroke="var(--color-border)"
+            strokeWidth={1}
+            opacity={0.5}
+          />
+        );
+      })}
+
+      {/* Score polygon */}
+      <polygon
+        points={polygonPoints}
+        fill="var(--color-champagne)"
+        fillOpacity={0.2}
+        stroke="var(--color-champagne)"
+        strokeWidth={2}
+      />
+
+      {/* Score points */}
+      {orderedScores.map((score, i) => {
+        const point = getPoint(i, score.meanScore);
+        const info = traitInfo[score.trait];
+        return (
+          <circle key={score.trait} cx={point.x} cy={point.y} r={6} fill={info.color} />
+        );
+      })}
+
+      {/* Labels */}
+      {orderedTraits.map((trait, i) => {
+        const angle = startAngle + i * angleStep;
+        const labelRadius = maxRadius + 30;
+        const x = center + labelRadius * Math.cos(angle);
+        const y = center + labelRadius * Math.sin(angle);
+        const info = traitInfo[trait];
+        // Shorten name for display
+        const shortName =
+          trait === 'machiavellianism' ? 'Mach' : trait === 'narcissism' ? 'Narc' : 'Psych';
+        return (
+          <text
+            key={trait}
+            x={x}
+            y={y}
+            textAnchor="middle"
+            dominantBaseline="middle"
+            className="text-xs font-medium"
+            fill={info.color}
+          >
+            {shortName}
+          </text>
+        );
+      })}
+    </svg>
+  );
+}
+
+interface TraitCardProps {
+  score: TraitScore;
+  isExpanded: boolean;
+  onToggle: () => void;
+}
+
+function TraitCard({ score, isExpanded, onToggle }: TraitCardProps) {
+  const info = traitInfo[score.trait];
+  const interpretation = getPercentileInterpretation(score.percentile);
+  const description = getTraitDescription(score.trait, score.percentile);
+
+  // Level indicator styling
+  const levelStyles = {
+    low: 'bg-green-500/20 text-green-400 border-green-500/30',
+    average: 'bg-blue-500/20 text-blue-400 border-blue-500/30',
+    high: 'bg-amber-500/20 text-amber-400 border-amber-500/30',
+  };
+
+  return (
+    <div className="card-premium rounded-lg overflow-hidden">
+      {/* Main card content */}
+      <button
+        onClick={onToggle}
+        className="w-full p-6 text-left hover:bg-[var(--color-bg-secondary)]/50 transition-colors duration-200"
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex-1">
+            <div className="flex items-center gap-3 mb-2">
+              <div className="w-3 h-3 rounded-full" style={{ backgroundColor: info.color }} />
+              <h4 className="font-display text-lg font-medium text-[var(--color-text-primary)]">
+                {info.name}
+              </h4>
+              <span
+                className={`px-2 py-0.5 rounded text-xs font-medium border ${levelStyles[score.level]}`}
+              >
+                {score.level.charAt(0).toUpperCase() + score.level.slice(1)}
+              </span>
+            </div>
+            <p className="text-[var(--color-text-secondary)] text-sm mb-4">{description}</p>
+
+            {/* Spectrum bar */}
+            <div className="relative h-2 bg-[var(--color-border)] rounded-full overflow-hidden">
+              <div
+                className="absolute h-full rounded-full transition-all duration-500"
+                style={{
+                  width: `${(score.meanScore / 5) * 100}%`,
+                  backgroundColor: info.color,
+                }}
+              />
+            </div>
+
+            {/* Score indicator */}
+            <div className="flex justify-between mt-2">
+              <span className="text-[var(--color-text-muted)] text-xs">1</span>
+              <span className="text-[var(--color-text-primary)] text-sm font-medium">
+                Mean: {score.meanScore.toFixed(2)} / 5 ({interpretation}, {score.percentile}th
+                percentile)
+              </span>
+              <span className="text-[var(--color-text-muted)] text-xs">5</span>
+            </div>
+          </div>
+
+          {/* Expand/collapse icon */}
+          <div className="text-[var(--color-text-muted)]">
+            <svg
+              className={`w-5 h-5 transition-transform duration-200 ${
+                isExpanded ? 'rotate-180' : ''
+              }`}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M19 9l-7 7-7-7"
+              />
+            </svg>
+          </div>
+        </div>
+      </button>
+
+      {/* Expanded description */}
+      {isExpanded && (
+        <div className="border-t border-[var(--color-border)] bg-[var(--color-bg-secondary)]/30 p-6">
+          <h5 className="text-[var(--color-text-muted)] text-xs uppercase tracking-wider mb-3">
+            About This Trait
+          </h5>
+          <p className="text-[var(--color-text-secondary)] text-sm leading-relaxed mb-4">
+            {info.description}
+          </p>
+
+          <h5 className="text-[var(--color-text-muted)] text-xs uppercase tracking-wider mb-3">
+            What Your Score Means
+          </h5>
+          <p className="text-[var(--color-text-secondary)] text-sm leading-relaxed">
+            {score.level === 'low' && (
+              <>
+                Your score is <strong>below average</strong> compared to the general population.
+                This suggests you may be less inclined toward the strategic, self-focused, or
+                bold behaviors associated with this trait.
+              </>
+            )}
+            {score.level === 'average' && (
+              <>
+                Your score falls within the <strong>average range</strong> for the general
+                population. Like most people, you likely exhibit these tendencies in moderation
+                and context-dependently.
+              </>
+            )}
+            {score.level === 'high' && (
+              <>
+                Your score is <strong>above average</strong> compared to the general population.
+                This may reflect greater comfort with strategic thinking, self-promotion, or
+                risk-taking. Remember: these are normal personality variations, not disorders.
+              </>
+            )}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/data/sd3-items.ts
+++ b/frontend/data/sd3-items.ts
@@ -1,0 +1,261 @@
+// Short Dark Triad (SD3) - 27-item measure of the Dark Triad
+// Source: Jones, D.N., & Paulhus, D.L. (2014). Introducing the Short Dark Triad (SD3):
+// A Brief Measure of Dark Personality Traits. Assessment, 21(1), 28-41.
+// License: Free for research with citation
+
+export type DarkTrait = 'machiavellianism' | 'narcissism' | 'psychopathy';
+
+export interface Item {
+  id: number;
+  text: string;
+  trait: DarkTrait;
+  isReversed: boolean;
+}
+
+export interface TraitInfo {
+  code: DarkTrait;
+  name: string;
+  description: string;
+  lowDescription: string;
+  highDescription: string;
+  color: string;
+}
+
+export const traitInfo: Record<DarkTrait, TraitInfo> = {
+  machiavellianism: {
+    code: 'machiavellianism',
+    name: 'Machiavellianism',
+    description:
+      'A strategic approach to social interactions characterized by a focus on self-interest, pragmatic ethics, and a preference for planning over impulsivity.',
+    lowDescription:
+      'You tend to be straightforward and trusting in your dealings with others, preferring direct communication over strategic maneuvering.',
+    highDescription:
+      'You tend to be strategic and calculating in social situations, carefully considering how to position yourself for advantage.',
+    color: '#6366f1', // indigo
+  },
+  narcissism: {
+    code: 'narcissism',
+    name: 'Narcissism',
+    description:
+      'A pattern of grandiosity, need for admiration, and sense of entitlement. At subclinical levels, reflects confidence and leadership tendencies.',
+    lowDescription:
+      'You tend to be modest and self-effacing, preferring to deflect attention and avoid the spotlight.',
+    highDescription:
+      'You tend to see yourself as special and deserving of recognition, often seeking leadership roles and admiration.',
+    color: '#f59e0b', // amber
+  },
+  psychopathy: {
+    code: 'psychopathy',
+    name: 'Psychopathy',
+    description:
+      'A pattern characterized by impulsivity, thrill-seeking, low empathy, and low anxiety. At subclinical levels, reflects boldness and risk tolerance.',
+    lowDescription:
+      'You tend to be cautious, empathetic, and considerate of consequences before acting.',
+    highDescription:
+      'You tend to be bold and action-oriented, with a higher tolerance for risk and confrontation.',
+    color: '#ef4444', // red
+  },
+};
+
+// All 27 SD3 items (9 per trait)
+export const items: Item[] = [
+  // === MACHIAVELLIANISM (items 1-9) ===
+  {
+    id: 1,
+    text: "It's not wise to tell your secrets.",
+    trait: 'machiavellianism',
+    isReversed: false,
+  },
+  {
+    id: 2,
+    text: 'I like to use clever manipulation to get my way.',
+    trait: 'machiavellianism',
+    isReversed: false,
+  },
+  {
+    id: 3,
+    text: 'Whatever it takes, you must get the important people on your side.',
+    trait: 'machiavellianism',
+    isReversed: false,
+  },
+  {
+    id: 4,
+    text: 'Avoid direct conflict with others because they may be useful in the future.',
+    trait: 'machiavellianism',
+    isReversed: false,
+  },
+  {
+    id: 5,
+    text: "It's wise to keep track of information that you can use against people later.",
+    trait: 'machiavellianism',
+    isReversed: false,
+  },
+  {
+    id: 6,
+    text: 'You should wait for the right time to get back at people.',
+    trait: 'machiavellianism',
+    isReversed: false,
+  },
+  {
+    id: 7,
+    text: "There are things you should hide from other people because they don't need to know.",
+    trait: 'machiavellianism',
+    isReversed: false,
+  },
+  {
+    id: 8,
+    text: 'Make sure your plans benefit you, not others.',
+    trait: 'machiavellianism',
+    isReversed: false,
+  },
+  {
+    id: 9,
+    text: 'Most people can be manipulated.',
+    trait: 'machiavellianism',
+    isReversed: false,
+  },
+
+  // === NARCISSISM (items 10-18) ===
+  {
+    id: 10,
+    text: 'People see me as a natural leader.',
+    trait: 'narcissism',
+    isReversed: false,
+  },
+  {
+    id: 11,
+    text: 'I hate being the center of attention.',
+    trait: 'narcissism',
+    isReversed: true,
+  },
+  {
+    id: 12,
+    text: 'Many group activities tend to be dull without me.',
+    trait: 'narcissism',
+    isReversed: false,
+  },
+  {
+    id: 13,
+    text: 'I know that I am special because everyone keeps telling me so.',
+    trait: 'narcissism',
+    isReversed: false,
+  },
+  {
+    id: 14,
+    text: 'I like to get acquainted with important people.',
+    trait: 'narcissism',
+    isReversed: false,
+  },
+  {
+    id: 15,
+    text: 'I feel embarrassed if someone compliments me.',
+    trait: 'narcissism',
+    isReversed: true,
+  },
+  {
+    id: 16,
+    text: 'I have been compared to famous people.',
+    trait: 'narcissism',
+    isReversed: false,
+  },
+  {
+    id: 17,
+    text: 'I am an average person.',
+    trait: 'narcissism',
+    isReversed: true,
+  },
+  {
+    id: 18,
+    text: 'I insist on getting the respect I deserve.',
+    trait: 'narcissism',
+    isReversed: false,
+  },
+
+  // === PSYCHOPATHY (items 19-27) ===
+  {
+    id: 19,
+    text: 'I like to get revenge on authorities.',
+    trait: 'psychopathy',
+    isReversed: false,
+  },
+  {
+    id: 20,
+    text: 'I avoid dangerous situations.',
+    trait: 'psychopathy',
+    isReversed: true,
+  },
+  {
+    id: 21,
+    text: 'Payback needs to be quick and nasty.',
+    trait: 'psychopathy',
+    isReversed: false,
+  },
+  {
+    id: 22,
+    text: "People often say I'm out of control.",
+    trait: 'psychopathy',
+    isReversed: false,
+  },
+  {
+    id: 23,
+    text: "It's true that I can be mean to others.",
+    trait: 'psychopathy',
+    isReversed: false,
+  },
+  {
+    id: 24,
+    text: 'People who mess with me always regret it.',
+    trait: 'psychopathy',
+    isReversed: false,
+  },
+  {
+    id: 25,
+    text: 'I have never gotten into trouble with the law.',
+    trait: 'psychopathy',
+    isReversed: true,
+  },
+  {
+    id: 26,
+    text: 'I enjoy having sex with people I hardly know.',
+    trait: 'psychopathy',
+    isReversed: false,
+  },
+  {
+    id: 27,
+    text: "I'll say anything to get what I want.",
+    trait: 'psychopathy',
+    isReversed: false,
+  },
+];
+
+// Get all traits
+export const traits: DarkTrait[] = ['machiavellianism', 'narcissism', 'psychopathy'];
+
+// Get items for a specific trait
+export function getItemsForTrait(trait: DarkTrait): Item[] {
+  return items.filter((item) => item.trait === trait);
+}
+
+// Shuffle items for the assessment (consistent shuffle based on seed)
+export function shuffleItems(seed: number = 42): Item[] {
+  const shuffled = [...items];
+  let currentIndex = shuffled.length;
+  let randomValue: number;
+
+  // Simple seeded random
+  const seededRandom = () => {
+    seed = (seed * 9301 + 49297) % 233280;
+    return seed / 233280;
+  };
+
+  while (currentIndex !== 0) {
+    randomValue = Math.floor(seededRandom() * currentIndex);
+    currentIndex--;
+    [shuffled[currentIndex], shuffled[randomValue]] = [
+      shuffled[randomValue],
+      shuffled[currentIndex],
+    ];
+  }
+
+  return shuffled;
+}

--- a/frontend/data/sd3-scoring.test.ts
+++ b/frontend/data/sd3-scoring.test.ts
@@ -1,0 +1,400 @@
+// Unit tests for SD3 scoring logic
+import { describe, it, expect } from 'vitest';
+import {
+  scoreItem,
+  calculateMean,
+  getItemsForTrait,
+  calculateTraitScore,
+  calculateAllScores,
+  calculateTraitPercentile,
+  getTraitLevel,
+  getPercentileInterpretation,
+  getTraitDescription,
+  serializeResults,
+  deserializeResults,
+  serializeResponses,
+  deserializeResponses,
+  type Response,
+} from './sd3-scoring';
+import { items, traits, type Item, type DarkTrait } from './sd3-items';
+
+describe('SD3 Scoring', () => {
+  describe('scoreItem', () => {
+    it('returns value unchanged for non-reversed items', () => {
+      const item: Item = {
+        id: 1,
+        text: 'Test item',
+        trait: 'machiavellianism',
+        isReversed: false,
+      };
+      expect(scoreItem(item, 1)).toBe(1);
+      expect(scoreItem(item, 3)).toBe(3);
+      expect(scoreItem(item, 5)).toBe(5);
+    });
+
+    it('reverses value for reversed items (6 - value)', () => {
+      const item: Item = {
+        id: 11,
+        text: 'I hate being the center of attention.',
+        trait: 'narcissism',
+        isReversed: true,
+      };
+      expect(scoreItem(item, 1)).toBe(5);
+      expect(scoreItem(item, 2)).toBe(4);
+      expect(scoreItem(item, 3)).toBe(3);
+      expect(scoreItem(item, 4)).toBe(2);
+      expect(scoreItem(item, 5)).toBe(1);
+    });
+
+    it('correctly handles actual reversed items from the SD3', () => {
+      // Item 11: "I hate being the center of attention." (narcissism, reversed)
+      const item11 = items.find((i) => i.id === 11)!;
+      expect(item11.isReversed).toBe(true);
+      expect(scoreItem(item11, 5)).toBe(1); // Strongly agree with hating attention = low narcissism
+
+      // Item 17: "I am an average person." (narcissism, reversed)
+      const item17 = items.find((i) => i.id === 17)!;
+      expect(item17.isReversed).toBe(true);
+      expect(scoreItem(item17, 5)).toBe(1); // Strongly agree with being average = low narcissism
+
+      // Item 20: "I avoid dangerous situations." (psychopathy, reversed)
+      const item20 = items.find((i) => i.id === 20)!;
+      expect(item20.isReversed).toBe(true);
+      expect(scoreItem(item20, 5)).toBe(1); // Strongly agree with avoiding danger = low psychopathy
+
+      // Item 25: "I have never gotten into trouble with the law." (psychopathy, reversed)
+      const item25 = items.find((i) => i.id === 25)!;
+      expect(item25.isReversed).toBe(true);
+      expect(scoreItem(item25, 5)).toBe(1); // Strongly agree with no legal trouble = low psychopathy
+    });
+  });
+
+  describe('calculateMean', () => {
+    it('returns 0 for empty array', () => {
+      expect(calculateMean([])).toBe(0);
+    });
+
+    it('calculates mean correctly for single value', () => {
+      expect(calculateMean([5])).toBe(5);
+    });
+
+    it('calculates mean correctly for multiple values', () => {
+      expect(calculateMean([1, 2, 3, 4, 5])).toBe(3);
+      expect(calculateMean([2, 4])).toBe(3);
+      expect(calculateMean([1, 1, 1, 1])).toBe(1);
+    });
+  });
+
+  describe('getItemsForTrait', () => {
+    it('returns 9 items for each trait', () => {
+      for (const trait of traits) {
+        const traitItems = getItemsForTrait(trait);
+        expect(traitItems.length).toBe(9);
+        expect(traitItems.every((item) => item.trait === trait)).toBe(true);
+      }
+    });
+
+    it('returns items with correct IDs for machiavellianism (1-9)', () => {
+      const machItems = getItemsForTrait('machiavellianism');
+      const ids = machItems.map((i) => i.id).sort((a, b) => a - b);
+      expect(ids).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    });
+
+    it('returns items with correct IDs for narcissism (10-18)', () => {
+      const narcItems = getItemsForTrait('narcissism');
+      const ids = narcItems.map((i) => i.id).sort((a, b) => a - b);
+      expect(ids).toEqual([10, 11, 12, 13, 14, 15, 16, 17, 18]);
+    });
+
+    it('returns items with correct IDs for psychopathy (19-27)', () => {
+      const psychItems = getItemsForTrait('psychopathy');
+      const ids = psychItems.map((i) => i.id).sort((a, b) => a - b);
+      expect(ids).toEqual([19, 20, 21, 22, 23, 24, 25, 26, 27]);
+    });
+  });
+
+  describe('calculateTraitScore', () => {
+    it('calculates trait score correctly with all same responses', () => {
+      const traitItems = getItemsForTrait('machiavellianism');
+      const responses = new Map<number, number>();
+
+      // Set all responses to 4
+      for (const item of traitItems) {
+        responses.set(item.id, 4);
+      }
+
+      const score = calculateTraitScore('machiavellianism', responses);
+      expect(score.trait).toBe('machiavellianism');
+      expect(score.rawScore).toBe(36); // 9 items * 4
+      expect(score.meanScore).toBe(4);
+      expect(score.percentile).toBeGreaterThanOrEqual(0);
+      expect(score.percentile).toBeLessThanOrEqual(100);
+    });
+
+    it('handles reverse-scored items correctly in narcissism', () => {
+      // Narcissism has 3 reversed items: 11, 15, 17
+      const responses = new Map<number, number>();
+
+      // Non-reversed items (10, 12, 13, 14, 16, 18) = 4 each = 24
+      // Reversed items (11, 15, 17) = 4 each -> 6-4=2 each = 6
+      // Total raw = 30, mean = 30/9 = 3.33...
+
+      for (const item of getItemsForTrait('narcissism')) {
+        responses.set(item.id, 4);
+      }
+
+      const score = calculateTraitScore('narcissism', responses);
+      // 6 non-reversed * 4 = 24
+      // 3 reversed: 6-4=2 each = 6
+      // Total = 30
+      expect(score.rawScore).toBe(30);
+      expect(score.meanScore).toBeCloseTo(30 / 9, 5);
+    });
+
+    it('handles reverse-scored items correctly in psychopathy', () => {
+      // Psychopathy has 2 reversed items: 20, 25
+      const responses = new Map<number, number>();
+
+      for (const item of getItemsForTrait('psychopathy')) {
+        responses.set(item.id, 5);
+      }
+
+      const score = calculateTraitScore('psychopathy', responses);
+      // 7 non-reversed * 5 = 35
+      // 2 reversed: 6-5=1 each = 2
+      // Total = 37
+      expect(score.rawScore).toBe(37);
+      expect(score.meanScore).toBeCloseTo(37 / 9, 5);
+    });
+
+    it('handles missing responses gracefully', () => {
+      const responses = new Map<number, number>();
+      const score = calculateTraitScore('machiavellianism', responses);
+      expect(score.rawScore).toBe(0);
+      expect(score.meanScore).toBe(0);
+    });
+  });
+
+  describe('calculateAllScores', () => {
+    it('returns scores for all 3 traits', () => {
+      const responses: Response[] = items.map((item) => ({
+        itemId: item.id,
+        value: 3,
+      }));
+
+      const results = calculateAllScores(responses);
+      expect(results.traits.length).toBe(3);
+      expect(results.totalQuestions).toBe(27);
+      expect(results.completedAt).toBeDefined();
+    });
+
+    it('calculates different scores for different response patterns', () => {
+      // All low responses
+      const lowResponses: Response[] = items.map((item) => ({
+        itemId: item.id,
+        value: 1,
+      }));
+      const lowResults = calculateAllScores(lowResponses);
+
+      // All high responses
+      const highResponses: Response[] = items.map((item) => ({
+        itemId: item.id,
+        value: 5,
+      }));
+      const highResults = calculateAllScores(highResponses);
+
+      // Scores should differ
+      for (let i = 0; i < 3; i++) {
+        expect(lowResults.traits[i].rawScore).not.toBe(highResults.traits[i].rawScore);
+      }
+    });
+  });
+
+  describe('getTraitLevel', () => {
+    it('returns correct level for machiavellianism', () => {
+      // Low: < 2.1, Average: 2.1-3.9, High: > 3.9
+      expect(getTraitLevel('machiavellianism', 1.5)).toBe('low');
+      expect(getTraitLevel('machiavellianism', 2.0)).toBe('low');
+      expect(getTraitLevel('machiavellianism', 2.1)).toBe('average');
+      expect(getTraitLevel('machiavellianism', 3.0)).toBe('average');
+      expect(getTraitLevel('machiavellianism', 3.9)).toBe('average');
+      expect(getTraitLevel('machiavellianism', 4.0)).toBe('high');
+      expect(getTraitLevel('machiavellianism', 4.5)).toBe('high');
+    });
+
+    it('returns correct level for narcissism', () => {
+      // Low: < 2.0, Average: 2.0-3.7, High: > 3.7
+      expect(getTraitLevel('narcissism', 1.5)).toBe('low');
+      expect(getTraitLevel('narcissism', 1.9)).toBe('low');
+      expect(getTraitLevel('narcissism', 2.0)).toBe('average');
+      expect(getTraitLevel('narcissism', 2.85)).toBe('average');
+      expect(getTraitLevel('narcissism', 3.7)).toBe('average');
+      expect(getTraitLevel('narcissism', 3.8)).toBe('high');
+      expect(getTraitLevel('narcissism', 4.5)).toBe('high');
+    });
+
+    it('returns correct level for psychopathy', () => {
+      // Low: < 1.2, Average: 1.2-2.8, High: > 2.8
+      expect(getTraitLevel('psychopathy', 1.0)).toBe('low');
+      expect(getTraitLevel('psychopathy', 1.1)).toBe('low');
+      expect(getTraitLevel('psychopathy', 1.2)).toBe('average');
+      expect(getTraitLevel('psychopathy', 2.0)).toBe('average');
+      expect(getTraitLevel('psychopathy', 2.8)).toBe('average');
+      expect(getTraitLevel('psychopathy', 2.9)).toBe('high');
+      expect(getTraitLevel('psychopathy', 4.0)).toBe('high');
+    });
+  });
+
+  describe('percentile calculations', () => {
+    describe('calculateTraitPercentile', () => {
+      it('returns percentile between 0 and 100', () => {
+        for (const trait of traits) {
+          const percentile = calculateTraitPercentile(trait, 3.0);
+          expect(percentile).toBeGreaterThanOrEqual(0);
+          expect(percentile).toBeLessThanOrEqual(100);
+        }
+      });
+
+      it('returns higher percentile for higher scores', () => {
+        const lowPercentile = calculateTraitPercentile('machiavellianism', 1.5);
+        const highPercentile = calculateTraitPercentile('machiavellianism', 4.5);
+        expect(highPercentile).toBeGreaterThan(lowPercentile);
+      });
+
+      it('returns ~50th percentile for mean score', () => {
+        // Machiavellianism has mean of 3.0
+        const percentile = calculateTraitPercentile('machiavellianism', 3.0);
+        expect(percentile).toBeGreaterThanOrEqual(45);
+        expect(percentile).toBeLessThanOrEqual(55);
+      });
+    });
+  });
+
+  describe('getPercentileInterpretation', () => {
+    it('returns correct interpretation for each range', () => {
+      expect(getPercentileInterpretation(90)).toBe('Very High');
+      expect(getPercentileInterpretation(85)).toBe('Very High');
+      expect(getPercentileInterpretation(75)).toBe('High');
+      expect(getPercentileInterpretation(70)).toBe('High');
+      expect(getPercentileInterpretation(60)).toBe('Above Average');
+      expect(getPercentileInterpretation(55)).toBe('Above Average');
+      expect(getPercentileInterpretation(50)).toBe('Average');
+      expect(getPercentileInterpretation(45)).toBe('Average');
+      expect(getPercentileInterpretation(35)).toBe('Below Average');
+      expect(getPercentileInterpretation(30)).toBe('Below Average');
+      expect(getPercentileInterpretation(20)).toBe('Low');
+      expect(getPercentileInterpretation(15)).toBe('Low');
+      expect(getPercentileInterpretation(10)).toBe('Very Low');
+      expect(getPercentileInterpretation(5)).toBe('Very Low');
+    });
+  });
+
+  describe('getTraitDescription', () => {
+    it('returns high description for percentile >= 50', () => {
+      const desc = getTraitDescription('machiavellianism', 75);
+      expect(desc).toContain('strategic');
+    });
+
+    it('returns low description for percentile < 50', () => {
+      const desc = getTraitDescription('machiavellianism', 25);
+      expect(desc).toContain('straightforward');
+    });
+  });
+
+  describe('serialization', () => {
+    describe('serializeResults / deserializeResults', () => {
+      it('round-trips results correctly', () => {
+        const responses: Response[] = items.slice(0, 10).map((item) => ({
+          itemId: item.id,
+          value: 3,
+        }));
+        const results = calculateAllScores(responses);
+
+        const serialized = serializeResults(results);
+        const deserialized = deserializeResults(serialized);
+
+        expect(deserialized).not.toBeNull();
+        expect(deserialized?.traits.length).toBe(results.traits.length);
+        expect(deserialized?.totalQuestions).toBe(results.totalQuestions);
+      });
+
+      it('returns null for invalid JSON', () => {
+        expect(deserializeResults('invalid json')).toBeNull();
+        expect(deserializeResults('{broken')).toBeNull();
+      });
+    });
+
+    describe('serializeResponses / deserializeResponses', () => {
+      it('round-trips responses correctly', () => {
+        const responses: Response[] = [
+          { itemId: 1, value: 3 },
+          { itemId: 2, value: 4 },
+          { itemId: 3, value: 5 },
+        ];
+
+        const serialized = serializeResponses(responses);
+        const deserialized = deserializeResponses(serialized);
+
+        expect(deserialized).toEqual(responses);
+      });
+
+      it('returns null for invalid JSON', () => {
+        expect(deserializeResponses('invalid json')).toBeNull();
+      });
+    });
+  });
+});
+
+describe('SD3 Items Data Integrity', () => {
+  it('has 27 items total', () => {
+    expect(items.length).toBe(27);
+  });
+
+  it('has 3 traits', () => {
+    expect(traits.length).toBe(3);
+    expect(traits).toContain('machiavellianism');
+    expect(traits).toContain('narcissism');
+    expect(traits).toContain('psychopathy');
+  });
+
+  it('has 9 items per trait', () => {
+    for (const trait of traits) {
+      const traitItems = items.filter((item) => item.trait === trait);
+      expect(traitItems.length).toBe(9);
+    }
+  });
+
+  it('has unique item IDs', () => {
+    const ids = items.map((item) => item.id);
+    const uniqueIds = new Set(ids);
+    expect(uniqueIds.size).toBe(items.length);
+  });
+
+  it('has sequential item IDs from 1-27', () => {
+    const ids = items.map((item) => item.id).sort((a, b) => a - b);
+    expect(ids).toEqual(Array.from({ length: 27 }, (_, i) => i + 1));
+  });
+
+  it('has correct number of reversed items per trait', () => {
+    // Machiavellianism: 0 reversed
+    const machReversed = items.filter((i) => i.trait === 'machiavellianism' && i.isReversed);
+    expect(machReversed.length).toBe(0);
+
+    // Narcissism: 3 reversed (11, 15, 17)
+    const narcReversed = items.filter((i) => i.trait === 'narcissism' && i.isReversed);
+    expect(narcReversed.length).toBe(3);
+    expect(narcReversed.map((i) => i.id).sort((a, b) => a - b)).toEqual([11, 15, 17]);
+
+    // Psychopathy: 2 reversed (20, 25)
+    const psychReversed = items.filter((i) => i.trait === 'psychopathy' && i.isReversed);
+    expect(psychReversed.length).toBe(2);
+    expect(psychReversed.map((i) => i.id).sort((a, b) => a - b)).toEqual([20, 25]);
+  });
+
+  it('has mix of reversed and non-reversed items overall', () => {
+    const reversed = items.filter((item) => item.isReversed);
+    const nonReversed = items.filter((item) => !item.isReversed);
+    expect(reversed.length).toBe(5); // 0 + 3 + 2
+    expect(nonReversed.length).toBe(22);
+  });
+});

--- a/frontend/data/sd3-scoring.ts
+++ b/frontend/data/sd3-scoring.ts
@@ -1,0 +1,180 @@
+// SD3 Scoring Logic
+// Based on Jones & Paulhus (2014) Short Dark Triad
+// Reference: Assessment, 21(1), 28-41
+
+import { type DarkTrait, type Item, items, traits, getItemsForTrait, traitInfo } from './sd3-items';
+
+export interface Response {
+  itemId: number;
+  value: number; // 1-5 Likert scale (strongly disagree to strongly agree)
+}
+
+export interface TraitScore {
+  trait: DarkTrait;
+  rawScore: number; // Sum of 9 items (after reverse scoring)
+  meanScore: number; // 1-5 scale
+  percentile: number;
+  level: 'low' | 'average' | 'high';
+}
+
+export interface SD3Results {
+  traits: TraitScore[];
+  completedAt: string;
+  totalQuestions: number;
+}
+
+// Apply reverse scoring if needed
+// Reverse scoring: (6 - response) for reversed items
+export function scoreItem(item: Item, value: number): number {
+  if (item.isReversed) {
+    return 6 - value;
+  }
+  return value;
+}
+
+// Calculate mean score from array of scores
+export function calculateMean(scores: number[]): number {
+  if (scores.length === 0) return 0;
+  return scores.reduce((sum, score) => sum + score, 0) / scores.length;
+}
+
+// Get items for a specific trait (re-exported for convenience)
+export { getItemsForTrait };
+
+// Calculate trait score
+export function calculateTraitScore(
+  trait: DarkTrait,
+  responses: Map<number, number>
+): TraitScore {
+  const traitItems = getItemsForTrait(trait);
+  const scores: number[] = [];
+
+  for (const item of traitItems) {
+    const value = responses.get(item.id);
+    if (value !== undefined) {
+      scores.push(scoreItem(item, value));
+    }
+  }
+
+  const rawScore = scores.reduce((sum, s) => sum + s, 0);
+  const meanScore = calculateMean(scores);
+  const percentile = calculateTraitPercentile(trait, meanScore);
+  const level = getTraitLevel(trait, meanScore);
+
+  return {
+    trait,
+    rawScore,
+    meanScore,
+    percentile,
+    level,
+  };
+}
+
+// Calculate all scores from responses
+export function calculateAllScores(responses: Response[]): SD3Results {
+  const responseMap = new Map<number, number>();
+  responses.forEach((r) => responseMap.set(r.itemId, r.value));
+
+  const traitScores = traits.map((trait) => calculateTraitScore(trait, responseMap));
+
+  return {
+    traits: traitScores,
+    completedAt: new Date().toISOString(),
+    totalQuestions: responses.length,
+  };
+}
+
+// Population norms from the issue specification
+// | Trait | Low | Average | High |
+// | Machiavellianism | <2.1 | 2.1-3.9 | >3.9 |
+// | Narcissism | <2.0 | 2.0-3.7 | >3.7 |
+// | Psychopathy | <1.2 | 1.2-2.8 | >2.8 |
+
+const traitNorms: Record<DarkTrait, { mean: number; sd: number; lowCutoff: number; highCutoff: number }> = {
+  machiavellianism: { mean: 3.0, sd: 0.75, lowCutoff: 2.1, highCutoff: 3.9 },
+  narcissism: { mean: 2.85, sd: 0.70, lowCutoff: 2.0, highCutoff: 3.7 },
+  psychopathy: { mean: 2.0, sd: 0.65, lowCutoff: 1.2, highCutoff: 2.8 },
+};
+
+// Get trait level based on cutoffs from population norms
+export function getTraitLevel(trait: DarkTrait, meanScore: number): 'low' | 'average' | 'high' {
+  const norm = traitNorms[trait];
+  if (meanScore < norm.lowCutoff) return 'low';
+  if (meanScore > norm.highCutoff) return 'high';
+  return 'average';
+}
+
+// Convert z-score to percentile using standard normal CDF approximation
+function zToPercentile(z: number): number {
+  // Approximation of the standard normal CDF
+  const a1 = 0.254829592;
+  const a2 = -0.284496736;
+  const a3 = 1.421413741;
+  const a4 = -1.453152027;
+  const a5 = 1.061405429;
+  const p = 0.3275911;
+
+  const sign = z < 0 ? -1 : 1;
+  const absZ = Math.abs(z);
+
+  const t = 1.0 / (1.0 + p * absZ);
+  const y = 1.0 - ((((a5 * t + a4) * t + a3) * t + a2) * t + a1) * t * Math.exp((-absZ * absZ) / 2);
+
+  const cdf = 0.5 * (1.0 + sign * y);
+  return Math.round(cdf * 100);
+}
+
+// Calculate percentile for a trait score
+export function calculateTraitPercentile(trait: DarkTrait, meanScore: number): number {
+  const norm = traitNorms[trait];
+  const z = (meanScore - norm.mean) / norm.sd;
+  return zToPercentile(z);
+}
+
+// Get interpretation text based on percentile
+export function getPercentileInterpretation(percentile: number): string {
+  if (percentile >= 85) return 'Very High';
+  if (percentile >= 70) return 'High';
+  if (percentile >= 55) return 'Above Average';
+  if (percentile >= 45) return 'Average';
+  if (percentile >= 30) return 'Below Average';
+  if (percentile >= 15) return 'Low';
+  return 'Very Low';
+}
+
+// Get description based on trait and score level
+export function getTraitDescription(trait: DarkTrait, percentile: number): string {
+  const info = traitInfo[trait];
+  if (percentile >= 50) {
+    return info.highDescription;
+  }
+  return info.lowDescription;
+}
+
+// Serialize results to JSON for localStorage
+export function serializeResults(results: SD3Results): string {
+  return JSON.stringify(results);
+}
+
+// Deserialize results from JSON
+export function deserializeResults(json: string): SD3Results | null {
+  try {
+    return JSON.parse(json) as SD3Results;
+  } catch {
+    return null;
+  }
+}
+
+// Serialize responses to JSON for localStorage (for pause/resume)
+export function serializeResponses(responses: Response[]): string {
+  return JSON.stringify(responses);
+}
+
+// Deserialize responses from JSON
+export function deserializeResponses(json: string): Response[] | null {
+  try {
+    return JSON.parse(json) as Response[];
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds the 27-item Short Dark Triad (SD3) assessment measuring subclinical Machiavellianism, Narcissism, and Psychopathy
- Based on Jones & Paulhus (2014) with proper reverse scoring for 5 items
- Includes population norms, percentile calculations, and careful subclinical framing
- Full unit test coverage (36 tests) and E2E test coverage

## Key Features
- Progress saving/resume functionality
- Triangle radar chart visualization of results
- Prominent disclaimers about subclinical vs clinical interpretation
- Citation included in results

## Test plan
- [x] Unit tests pass (36 new tests in sd3-scoring.test.ts)
- [ ] E2E tests pass
- [ ] Verify assessment flow: start -> answer 27 questions -> see results
- [ ] Verify results display all 3 traits with percentiles and descriptions
- [ ] Verify disclaimers are visible on intro and results pages

Closes #29

Generated with [Claude Code](https://claude.com/claude-code)