### PR TITLE
Implement Reading the Mind in the Eyes Test (RMET)

### DIFF
--- a/e2e/rmet.spec.ts
+++ b/e2e/rmet.spec.ts
@@ -1,0 +1,185 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('RMET Assessment', () => {
+  test.beforeEach(async ({ page }) => {
+    // Clear localStorage before each test
+    await page.goto('/');
+    await page.evaluate(() => localStorage.clear());
+  });
+
+  test('complete assessment and see results', async ({ page }) => {
+    // Navigate to RMET assessment
+    await page.goto('/test/rmet');
+
+    // Verify intro page
+    await expect(page.getByRole('heading', { name: 'Reading the Mind in the Eyes Test' })).toBeVisible();
+
+    // Start the assessment
+    await page.getByRole('button', { name: /Begin Assessment/i }).click();
+
+    // Should see practice question indicator
+    await expect(page.getByText('Practice Question', { exact: true })).toBeVisible();
+
+    // Click first option to complete practice
+    const practiceOptions = page.locator('button').filter({ hasText: /jealous|panicked|arrogant|hateful/i });
+    await practiceOptions.first().click();
+
+    // Now in main assessment - answer all 36 questions
+    for (let i = 1; i <= 36; i++) {
+      // Verify we're on question i
+      await expect(page.getByText(`${i} of 36`)).toBeVisible();
+
+      // Click the first option for each question
+      const options = page.locator('main button').filter({ has: page.locator('span') });
+      await options.first().click();
+    }
+
+    // Should see completion screen
+    await expect(page.getByText('Assessment Complete')).toBeVisible();
+
+    // Click to view results
+    await page.getByRole('button', { name: /View Results/i }).click();
+
+    // Verify we're on the results page
+    await expect(page).toHaveURL('/test/rmet/results');
+
+    // Verify results are displayed
+    await expect(page.getByText('Reading the Mind in the Eyes')).toBeVisible();
+    await expect(page.getByText('Your Results')).toBeVisible();
+    await expect(page.getByText('of 36')).toBeVisible();
+  });
+
+  test('can resume progress after navigating away', async ({ page }) => {
+    // Start assessment
+    await page.goto('/test/rmet');
+    await page.getByRole('button', { name: /Begin Assessment/i }).click();
+
+    // Complete practice
+    const practiceOptions = page.locator('button').filter({ hasText: /jealous|panicked|arrogant|hateful/i });
+    await practiceOptions.first().click();
+
+    // Answer first 5 questions
+    for (let i = 0; i < 5; i++) {
+      const options = page.locator('main button').filter({ has: page.locator('span') });
+      await options.first().click();
+    }
+
+    // Verify we're on question 6
+    await expect(page.getByText('6 of 36')).toBeVisible();
+
+    // Navigate away
+    await page.goto('/');
+
+    // Return to assessment
+    await page.goto('/test/rmet');
+
+    // Should see Resume Progress button
+    await expect(page.getByRole('button', { name: /Resume Progress/i })).toBeVisible();
+
+    // Resume progress
+    await page.getByRole('button', { name: /Resume Progress/i }).click();
+
+    // Should be on question 6
+    await expect(page.getByText('6 of 36')).toBeVisible();
+  });
+
+  test('shows placeholder images when images are unavailable', async ({ page }) => {
+    // Start assessment
+    await page.goto('/test/rmet');
+    await page.getByRole('button', { name: /Begin Assessment/i }).click();
+
+    // Complete practice to get to main assessment
+    const practiceOptions = page.locator('button').filter({ hasText: /jealous|panicked|arrogant|hateful/i });
+    await practiceOptions.first().click();
+
+    // Should show placeholder image (since we don't have actual images)
+    await expect(page.locator('[data-testid="rmet-image-placeholder"]')).toBeVisible();
+  });
+
+  test('shows definition tooltip on hover for difficult words', async ({ page }) => {
+    // Start assessment
+    await page.goto('/test/rmet');
+    await page.getByRole('button', { name: /Begin Assessment/i }).click();
+
+    // Practice item has "panicked" which doesn't have a tooltip, but let's
+    // advance to an item that has definitions
+    // Complete practice
+    const practiceOptions = page.locator('button').filter({ hasText: /jealous|panicked|arrogant|hateful/i });
+    await practiceOptions.first().click();
+
+    // Answer questions until we get to one with definitions (item 6 has "aghast" and "fantasizing")
+    for (let i = 0; i < 5; i++) {
+      const options = page.locator('main button').filter({ has: page.locator('span') });
+      await options.first().click();
+    }
+
+    // Now on question 6, hover over a word with definition if present
+    // Check that a word with dotted underline exists
+    const wordWithDefinition = page.locator('span.border-dotted').first();
+    if (await wordWithDefinition.count() > 0) {
+      await wordWithDefinition.hover();
+      // Tooltip should appear
+      await expect(page.locator('.z-10').filter({ hasText: /./i })).toBeVisible();
+    }
+  });
+
+  test('can go back to previous question', async ({ page }) => {
+    // Start assessment
+    await page.goto('/test/rmet');
+    await page.getByRole('button', { name: /Begin Assessment/i }).click();
+
+    // Complete practice
+    const practiceOptions = page.locator('button').filter({ hasText: /jealous|panicked|arrogant|hateful/i });
+    await practiceOptions.first().click();
+
+    // Answer first 2 questions
+    for (let i = 0; i < 2; i++) {
+      const options = page.locator('main button').filter({ has: page.locator('span') });
+      await options.first().click();
+    }
+
+    // Should be on question 3
+    await expect(page.getByText('3 of 36')).toBeVisible();
+
+    // Click back button
+    await page.getByRole('button', { name: /Previous Question/i }).click();
+
+    // Should be on question 2
+    await expect(page.getByText('2 of 36')).toBeVisible();
+  });
+
+  test('displays RMET card on home page', async ({ page }) => {
+    await page.goto('/');
+
+    // Should see RMET test card
+    await expect(page.getByRole('heading', { name: 'RMET' })).toBeVisible();
+    await expect(page.getByText('Eyes Test')).toBeVisible();
+    await expect(page.getByText('Social Cognition', { exact: false }).first()).toBeVisible();
+  });
+
+  test('results page shows item breakdown', async ({ page }) => {
+    // Complete full assessment first
+    await page.goto('/test/rmet');
+    await page.getByRole('button', { name: /Begin Assessment/i }).click();
+
+    // Complete practice
+    const practiceOptions = page.locator('button').filter({ hasText: /jealous|panicked|arrogant|hateful/i });
+    await practiceOptions.first().click();
+
+    // Answer all 36 questions quickly by clicking first option
+    for (let i = 1; i <= 36; i++) {
+      const options = page.locator('main button').filter({ has: page.locator('span') });
+      await options.first().click();
+    }
+
+    // View results
+    await page.getByRole('button', { name: /View Results/i }).click();
+
+    // Click to expand item breakdown
+    await page.getByText('Item-by-Item Breakdown').click();
+
+    // Should see item results
+    await expect(page.getByText('#1', { exact: true })).toBeVisible();
+    await expect(page.getByText('#36', { exact: true })).toBeVisible();
+  });
+});

--- a/e2e/rmet.spec.ts
+++ b/e2e/rmet.spec.ts
@@ -44,9 +44,9 @@ test.describe('RMET Assessment', () => {
     await expect(page).toHaveURL('/test/rmet/results');
 
     // Verify results are displayed
-    await expect(page.getByText('Reading the Mind in the Eyes')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Reading the Mind in the Eyes' })).toBeVisible();
     await expect(page.getByText('Your Results')).toBeVisible();
-    await expect(page.getByText('of 36')).toBeVisible();
+    await expect(page.getByText('of 36', { exact: true })).toBeVisible();
   });
 
   test('can resume progress after navigating away', async ({ page }) => {

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -13,6 +13,8 @@ import { FeatureFlagsProvider, useFeatureFlags } from './contexts/FeatureFlagsCo
 import { UserMenu } from './components/UserMenu';
 import { ResultsHistory } from './pages/ResultsHistory';
 import MiniTestAssessment from './components/MiniTestAssessment';
+import RMETAssessment from './components/RMETAssessment';
+import RMETResults from './components/RMETResults';
 
 // Theme Context
 type Theme = 'dark' | 'light';
@@ -218,6 +220,20 @@ function HomePage() {
               time="10 min"
               seriousness={2}
               fun={5}
+            />
+          </div>
+
+          {/* Additional Tests Row */}
+          <div className="grid md:grid-cols-3 gap-8 mt-8">
+            <TestCard
+              title="RMET"
+              subtitle="Eyes Test"
+              slug="rmet"
+              keywords={['Social Cognition', 'Empathy', 'Theory of Mind']}
+              description="Measure your ability to recognize emotions and mental states from eye expressions. Research-backed assessment of social cognition."
+              time="10 min"
+              seriousness={4}
+              fun={4}
             />
           </div>
 
@@ -668,6 +684,8 @@ export default function App() {
             <Route path="/my-results" element={<ResultsHistory />} />
             <Route path="/test/big-five" element={<BigFiveAssessment />} />
             <Route path="/test/big-five/results" element={<BigFiveResults />} />
+            <Route path="/test/rmet" element={<RMETAssessment />} />
+            <Route path="/test/rmet/results" element={<RMETResults />} />
             <Route path="/test/:slug" element={<TestRouter />} />
             <Route
               path="/hexaco"

--- a/frontend/components/RMETAssessment.tsx
+++ b/frontend/components/RMETAssessment.tsx
@@ -1,0 +1,542 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import {
+  scoredItems,
+  practiceItem,
+  hasDefinition,
+  getDefinition,
+  type RMETItem,
+} from '../data/rmet-items';
+import {
+  type RMETResponse,
+  calculateResults,
+  serializeResponses,
+  deserializeResponses,
+  serializeResults,
+} from '../data/rmet-scoring';
+import { useAuth } from '../contexts/AuthContext';
+
+const STORAGE_KEY = 'mesearch-rmet-responses';
+const RESULTS_STORAGE_KEY = 'mesearch-rmet-results';
+
+type AssessmentPhase = 'intro' | 'practice' | 'assessment' | 'complete';
+
+export default function RMETAssessment() {
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const [phase, setPhase] = useState<AssessmentPhase>('intro');
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [responses, setResponses] = useState<RMETResponse[]>([]);
+  const [hasSavedProgress, setHasSavedProgress] = useState(false);
+  const [startTime, setStartTime] = useState<number | null>(null);
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
+  const [tooltipWord, setTooltipWord] = useState<string | null>(null);
+
+  // Check for saved progress
+  useEffect(() => {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved) {
+      const savedResponses = deserializeResponses(saved);
+      if (savedResponses && savedResponses.length > 0) {
+        setHasSavedProgress(true);
+      }
+    }
+  }, []);
+
+  // Resume saved progress
+  const resumeProgress = useCallback(() => {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved) {
+      const savedResponses = deserializeResponses(saved);
+      if (savedResponses) {
+        setResponses(savedResponses);
+        setCurrentIndex(savedResponses.length);
+        setPhase('assessment');
+        setStartTime(Date.now());
+      }
+    }
+  }, []);
+
+  // Start fresh assessment
+  const startFresh = useCallback(() => {
+    localStorage.removeItem(STORAGE_KEY);
+    setResponses([]);
+    setCurrentIndex(0);
+    setPhase('practice');
+  }, []);
+
+  // Start practice
+  const startPractice = useCallback(() => {
+    setPhase('practice');
+    setStartTime(Date.now());
+  }, []);
+
+  // Complete practice and start assessment
+  const completePractice = useCallback(() => {
+    setPhase('assessment');
+    setCurrentIndex(0);
+    setStartTime(Date.now());
+  }, []);
+
+  // Save progress to localStorage
+  const saveProgress = useCallback((newResponses: RMETResponse[]) => {
+    localStorage.setItem(STORAGE_KEY, serializeResponses(newResponses));
+  }, []);
+
+  // Save results to backend
+  const saveResultsToBackend = useCallback(
+    async (results: ReturnType<typeof calculateResults>) => {
+      if (!user) return;
+
+      setSaveStatus('saving');
+      try {
+        const res = await fetch('/api/results', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({
+            test_type: 'rmet',
+            scores: results,
+          }),
+        });
+
+        if (res.ok) {
+          setSaveStatus('saved');
+        } else {
+          setSaveStatus('error');
+        }
+      } catch {
+        setSaveStatus('error');
+      }
+    },
+    [user]
+  );
+
+  // Handle response selection
+  const handleResponse = useCallback(
+    (selectedAnswer: string) => {
+      if (phase === 'practice') {
+        // Practice item - just show feedback then continue
+        completePractice();
+        return;
+      }
+
+      const currentItem = scoredItems[currentIndex];
+      if (!currentItem) return;
+
+      const responseTime = startTime ? Date.now() - startTime : undefined;
+
+      const newResponse: RMETResponse = {
+        itemId: currentItem.id,
+        selectedAnswer,
+        responseTime,
+      };
+
+      const newResponses = [...responses, newResponse];
+      setResponses(newResponses);
+      saveProgress(newResponses);
+      setStartTime(Date.now()); // Reset for next item
+
+      // Check if assessment is complete
+      if (currentIndex + 1 >= scoredItems.length) {
+        const results = calculateResults(newResponses);
+        localStorage.setItem(RESULTS_STORAGE_KEY, serializeResults(results));
+        localStorage.removeItem(STORAGE_KEY);
+        setPhase('complete');
+        saveResultsToBackend(results);
+      } else {
+        setCurrentIndex(currentIndex + 1);
+      }
+    },
+    [
+      phase,
+      currentIndex,
+      responses,
+      startTime,
+      saveProgress,
+      completePractice,
+      saveResultsToBackend,
+    ]
+  );
+
+  // Go back to previous question
+  const handleBack = useCallback(() => {
+    if (currentIndex > 0 && phase === 'assessment') {
+      const newResponses = responses.slice(0, -1);
+      setResponses(newResponses);
+      saveProgress(newResponses);
+      setCurrentIndex(currentIndex - 1);
+      setStartTime(Date.now());
+    }
+  }, [currentIndex, phase, responses, saveProgress]);
+
+  // Render intro phase
+  if (phase === 'intro') {
+    return (
+      <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
+        <Header />
+        <main className="mx-auto max-w-2xl px-6 py-16">
+          <div className="card-premium rounded-lg p-10">
+            <div className="text-center mb-8">
+              <p className="text-[var(--color-champagne)] text-xs tracking-[0.3em] uppercase mb-4">
+                Assessment
+              </p>
+              <h2 className="font-display text-3xl font-medium text-[var(--color-text-primary)] mb-2 transition-colors duration-300">
+                Reading the Mind in the Eyes Test
+              </h2>
+              <p className="text-[var(--color-text-muted)] text-sm">RMET</p>
+            </div>
+
+            <div className="space-y-6 text-[var(--color-text-secondary)] text-sm leading-relaxed">
+              <p>
+                This assessment measures your ability to recognize{' '}
+                <strong className="text-[var(--color-text-primary)]">
+                  mental states
+                </strong>{' '}
+                and{' '}
+                <strong className="text-[var(--color-text-primary)]">emotions</strong>{' '}
+                from looking at photographs of people&apos;s eyes.
+              </p>
+
+              <div className="bg-[var(--color-bg-secondary)] rounded-lg p-6 space-y-4">
+                <h3 className="text-[var(--color-text-primary)] font-medium">
+                  How it works:
+                </h3>
+                <ul className="list-disc list-inside space-y-2 text-[var(--color-text-muted)]">
+                  <li>You will see 36 photographs of eye regions</li>
+                  <li>For each image, choose the word that best describes what the person is feeling or thinking</li>
+                  <li>There are 4 options per image - pick the one that fits best</li>
+                  <li>Hover or tap words with a dotted underline to see definitions</li>
+                  <li>Your progress is automatically saved</li>
+                </ul>
+              </div>
+
+              <div className="bg-[var(--color-discovery)]/10 border border-[var(--color-discovery-border)] rounded-lg p-4">
+                <p className="text-[var(--color-discovery)] text-sm font-medium mb-1">
+                  Research Note
+                </p>
+                <p className="text-[var(--color-text-muted)] text-xs">
+                  The RMET was developed by Baron-Cohen et al. (2001) at the Autism
+                  Research Centre. It measures &quot;theory of mind&quot; - the ability to
+                  attribute mental states to others.
+                </p>
+              </div>
+
+              <p className="text-[var(--color-text-muted)] text-xs">
+                Note: For some words, definitions are available. Look for the dotted
+                underline.
+              </p>
+            </div>
+
+            <div className="mt-10 space-y-4">
+              {hasSavedProgress ? (
+                <>
+                  <button
+                    onClick={resumeProgress}
+                    className="btn-gold w-full py-4 rounded text-sm tracking-widest uppercase"
+                  >
+                    Resume Progress
+                  </button>
+                  <button
+                    onClick={startFresh}
+                    className="btn-ghost w-full py-4 rounded text-sm tracking-widest uppercase"
+                  >
+                    Start Over
+                  </button>
+                </>
+              ) : (
+                <button
+                  onClick={startPractice}
+                  className="btn-gold w-full py-4 rounded text-sm tracking-widest uppercase"
+                >
+                  Begin Assessment
+                </button>
+              )}
+            </div>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  // Render completion phase
+  if (phase === 'complete') {
+    return (
+      <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
+        <Header />
+        <main className="mx-auto max-w-2xl px-6 py-16">
+          <div className="card-premium rounded-lg p-10 text-center">
+            <div className="w-16 h-16 mx-auto mb-6 rounded-full border-2 border-[var(--color-champagne)] flex items-center justify-center">
+              <svg
+                className="w-8 h-8 text-[var(--color-champagne)]"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M5 13l4 4L19 7"
+                />
+              </svg>
+            </div>
+            <p className="text-[var(--color-champagne)] text-xs tracking-[0.3em] uppercase mb-4">
+              Complete
+            </p>
+            <h2 className="font-display text-3xl font-medium text-[var(--color-text-primary)] mb-4 transition-colors duration-300">
+              Assessment Complete
+            </h2>
+            <p className="text-[var(--color-text-secondary)] mb-4">
+              Thank you for completing the Reading the Mind in the Eyes Test. Your
+              results are ready.
+            </p>
+            {saveStatus === 'saving' && (
+              <p className="text-[var(--color-text-muted)] text-sm mb-4">
+                Saving results...
+              </p>
+            )}
+            {saveStatus === 'saved' && (
+              <p className="text-green-500 text-sm mb-4">Results saved to your account!</p>
+            )}
+            {saveStatus === 'error' && (
+              <p className="text-red-500 text-sm mb-4">
+                Could not save results. They are stored locally.
+              </p>
+            )}
+            <button
+              onClick={() => navigate('/test/rmet/results')}
+              className="btn-gold px-10 py-4 rounded text-sm tracking-widest uppercase"
+            >
+              View Results
+            </button>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  // Get current item (practice or scored)
+  const currentItem: RMETItem = phase === 'practice' ? practiceItem : scoredItems[currentIndex];
+  const totalItems = scoredItems.length;
+  const progress =
+    phase === 'practice' ? 0 : ((currentIndex + 1) / totalItems) * 100;
+
+  // Render assessment/practice phase
+  return (
+    <div className="min-h-screen bg-[var(--color-bg-primary)] flex flex-col transition-colors duration-300">
+      {/* Progress Header */}
+      <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
+        <div className="mx-auto max-w-3xl px-6 py-4">
+          <div className="flex items-center justify-between mb-3">
+            <Link
+              to="/"
+              className="font-display text-lg font-semibold tracking-wide text-gold-gradient"
+            >
+              Mesearch
+            </Link>
+            <span className="text-[var(--color-text-muted)] text-sm">
+              {phase === 'practice' ? (
+                'Practice'
+              ) : (
+                <>
+                  {currentIndex + 1} of {totalItems}
+                </>
+              )}
+            </span>
+          </div>
+          {/* Progress bar */}
+          <div className="h-1 bg-[var(--color-border)] rounded-full overflow-hidden">
+            <div
+              className="h-full bg-gradient-to-r from-[var(--color-champagne)] to-[var(--color-gold)] transition-all duration-300 ease-out"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+        </div>
+      </header>
+
+      {/* Question */}
+      <main className="flex-1 flex items-center justify-center px-6 py-8">
+        <div className="w-full max-w-xl">
+          {/* Practice indicator */}
+          {phase === 'practice' && (
+            <div className="text-center mb-6">
+              <span className="inline-block px-4 py-1 rounded-full bg-[var(--color-discovery)]/20 border border-[var(--color-discovery-border)] text-[var(--color-discovery)] text-xs tracking-wide uppercase">
+                Practice Question
+              </span>
+            </div>
+          )}
+
+          {/* Eye Image */}
+          <div className="mb-8">
+            <EyeImage item={currentItem} />
+          </div>
+
+          {/* Question prompt */}
+          <p className="text-center text-[var(--color-text-secondary)] text-sm mb-6">
+            Which word best describes what this person is feeling or thinking?
+          </p>
+
+          {/* Options */}
+          <div className="grid grid-cols-2 gap-3">
+            {currentItem.options.map((option) => {
+              const hasDef = hasDefinition(option);
+              return (
+                <button
+                  key={option}
+                  onClick={() => handleResponse(option)}
+                  onMouseEnter={() => hasDef && setTooltipWord(option)}
+                  onMouseLeave={() => setTooltipWord(null)}
+                  className="relative group"
+                >
+                  <div className="p-4 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-secondary)] hover:border-[var(--color-champagne)]/50 hover:bg-[var(--color-bg-secondary)]/80 transition-all duration-200 text-center">
+                    <span
+                      className={`text-[var(--color-text-secondary)] group-hover:text-[var(--color-text-primary)] transition-colors duration-200 capitalize ${
+                        hasDef
+                          ? 'border-b border-dotted border-[var(--color-text-muted)]'
+                          : ''
+                      }`}
+                    >
+                      {option}
+                    </span>
+                  </div>
+                  {/* Tooltip */}
+                  {tooltipWord === option && hasDef && (
+                    <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-2 bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-lg shadow-lg z-10 w-48">
+                      <p className="text-[var(--color-text-secondary)] text-xs">
+                        {getDefinition(option)}
+                      </p>
+                    </div>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Back button */}
+          {currentIndex > 0 && phase === 'assessment' && (
+            <div className="mt-8 text-center">
+              <button
+                onClick={handleBack}
+                className="text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] text-sm transition-colors duration-200"
+              >
+                &larr; Previous Question
+              </button>
+            </div>
+          )}
+        </div>
+      </main>
+
+      {/* Footer */}
+      <footer className="border-t border-[var(--color-border-subtle)] py-4 transition-colors duration-300">
+        <div className="mx-auto max-w-3xl px-6 flex justify-between items-center">
+          <p className="text-[var(--color-text-muted)] text-xs">
+            {phase === 'practice'
+              ? 'This is a practice question'
+              : 'Your progress is automatically saved'}
+          </p>
+          <Link
+            to="/"
+            className="text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] text-xs transition-colors duration-200"
+          >
+            Save & Exit
+          </Link>
+        </div>
+      </footer>
+    </div>
+  );
+}
+
+// Eye Image component - displays placeholder or actual image
+function EyeImage({ item }: { item: RMETItem }) {
+  const [imageError, setImageError] = useState(false);
+  const [imageLoaded, setImageLoaded] = useState(false);
+
+  // Reset state when item changes
+  useEffect(() => {
+    setImageError(false);
+    setImageLoaded(false);
+  }, [item.id]);
+
+  // For development/testing, show a placeholder
+  // In production, this would load actual licensed images
+  const showPlaceholder = imageError || !item.imageUrl.startsWith('http');
+
+  if (showPlaceholder) {
+    return (
+      <div
+        className="relative w-full aspect-[2/1] bg-[var(--color-bg-secondary)] rounded-lg border border-[var(--color-border)] flex items-center justify-center overflow-hidden"
+        data-testid="rmet-image-placeholder"
+      >
+        {/* Stylized eye placeholder */}
+        <svg
+          viewBox="0 0 200 100"
+          className="w-3/4 h-3/4 text-[var(--color-text-muted)]"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1"
+        >
+          {/* Eye outline */}
+          <path
+            d="M 20 50 Q 100 10 180 50 Q 100 90 20 50"
+            fill="var(--color-bg-tertiary)"
+          />
+          {/* Iris */}
+          <circle cx="100" cy="50" r="25" fill="var(--color-border)" />
+          {/* Pupil */}
+          <circle cx="100" cy="50" r="12" fill="var(--color-text-muted)" opacity="0.5" />
+          {/* Reflection */}
+          <circle cx="108" cy="42" r="5" fill="var(--color-bg-secondary)" />
+          {/* Eyebrow suggestion */}
+          <path
+            d="M 30 25 Q 100 5 170 25"
+            strokeWidth="3"
+            strokeLinecap="round"
+          />
+        </svg>
+        <div className="absolute bottom-2 right-2">
+          <span className="text-[var(--color-text-muted)] text-xs opacity-50">
+            #{item.id}
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative w-full aspect-[2/1] bg-[var(--color-bg-secondary)] rounded-lg border border-[var(--color-border)] overflow-hidden">
+      {!imageLoaded && (
+        <div className="absolute inset-0 flex items-center justify-center">
+          <div className="animate-pulse text-[var(--color-text-muted)] text-sm">
+            Loading...
+          </div>
+        </div>
+      )}
+      <img
+        src={item.imageUrl}
+        alt={`Eye photograph ${item.id}`}
+        className={`w-full h-full object-cover transition-opacity duration-200 ${
+          imageLoaded ? 'opacity-100' : 'opacity-0'
+        }`}
+        onLoad={() => setImageLoaded(true)}
+        onError={() => setImageError(true)}
+        data-testid="rmet-image"
+      />
+    </div>
+  );
+}
+
+function Header() {
+  return (
+    <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
+      <div className="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
+        <Link
+          to="/"
+          className="font-display text-2xl font-semibold tracking-wide text-gold-gradient"
+        >
+          Mesearch
+        </Link>
+      </div>
+    </header>
+  );
+}

--- a/frontend/components/RMETResults.tsx
+++ b/frontend/components/RMETResults.tsx
@@ -1,0 +1,457 @@
+import { useState, useEffect } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import {
+  type RMETResults as Results,
+  deserializeResults,
+  getScoreLevel,
+} from '../data/rmet-scoring';
+
+const RESULTS_STORAGE_KEY = 'mesearch-rmet-results';
+
+export default function RMETResults() {
+  const navigate = useNavigate();
+  const [results, setResults] = useState<Results | null>(null);
+  const [showItemBreakdown, setShowItemBreakdown] = useState(false);
+
+  useEffect(() => {
+    const saved = localStorage.getItem(RESULTS_STORAGE_KEY);
+    if (saved) {
+      const parsed = deserializeResults(saved);
+      setResults(parsed);
+    }
+  }, []);
+
+  if (!results) {
+    return (
+      <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
+        <Header />
+        <main className="mx-auto max-w-2xl px-6 py-16 text-center">
+          <div className="card-premium rounded-lg p-10">
+            <h2 className="font-display text-2xl font-medium text-[var(--color-text-primary)] mb-4">
+              No Results Found
+            </h2>
+            <p className="text-[var(--color-text-secondary)] mb-8">
+              You haven&apos;t completed the RMET assessment yet.
+            </p>
+            <button
+              onClick={() => navigate('/test/rmet')}
+              className="btn-gold px-8 py-3 rounded text-sm tracking-widest uppercase"
+            >
+              Take the Test
+            </button>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  const scoreLevel = getScoreLevel(results.totalCorrect);
+
+  return (
+    <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
+      <Header />
+      <main className="mx-auto max-w-4xl px-6 py-12">
+        {/* Title */}
+        <div className="text-center mb-12">
+          <p className="text-[var(--color-champagne)] text-xs tracking-[0.3em] uppercase mb-4">
+            Your Results
+          </p>
+          <h2 className="font-display text-4xl font-medium text-[var(--color-text-primary)] mb-2 transition-colors duration-300">
+            Reading the Mind in the Eyes
+          </h2>
+          <p className="text-[var(--color-text-muted)] text-sm">
+            Completed {new Date(results.completedAt).toLocaleDateString()}
+          </p>
+        </div>
+
+        {/* Main Score Card */}
+        <div className="card-premium rounded-lg p-8 mb-8">
+          <div className="flex flex-col md:flex-row items-center gap-8">
+            {/* Score Circle */}
+            <div className="flex-shrink-0">
+              <ScoreCircle
+                score={results.totalCorrect}
+                total={results.totalQuestions}
+                percentile={results.percentile}
+              />
+            </div>
+
+            {/* Score Details */}
+            <div className="flex-1 text-center md:text-left">
+              <div className="flex items-center justify-center md:justify-start gap-3 mb-4">
+                <h3 className="font-display text-2xl font-medium text-[var(--color-text-primary)]">
+                  {scoreLevel}
+                </h3>
+                <span className="px-3 py-1 rounded-full bg-[var(--color-champagne)]/20 text-[var(--color-champagne)] text-xs font-medium">
+                  {results.percentile}th percentile
+                </span>
+              </div>
+
+              <p className="text-[var(--color-text-secondary)] text-sm leading-relaxed mb-4">
+                {results.interpretation}
+              </p>
+
+              {/* Stats */}
+              <div className="grid grid-cols-2 md:grid-cols-3 gap-4 pt-4 border-t border-[var(--color-border)]">
+                <div>
+                  <p className="text-[var(--color-text-muted)] text-xs uppercase tracking-wider mb-1">
+                    Correct
+                  </p>
+                  <p className="text-[var(--color-text-primary)] text-lg font-medium">
+                    {results.totalCorrect} / {results.totalQuestions}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-[var(--color-text-muted)] text-xs uppercase tracking-wider mb-1">
+                    Accuracy
+                  </p>
+                  <p className="text-[var(--color-text-primary)] text-lg font-medium">
+                    {results.percentCorrect}%
+                  </p>
+                </div>
+                {results.averageResponseTime && (
+                  <div>
+                    <p className="text-[var(--color-text-muted)] text-xs uppercase tracking-wider mb-1">
+                      Avg. Time
+                    </p>
+                    <p className="text-[var(--color-text-primary)] text-lg font-medium">
+                      {(results.averageResponseTime / 1000).toFixed(1)}s
+                    </p>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Score Distribution */}
+        <div className="card-premium rounded-lg p-8 mb-8">
+          <h3 className="text-[var(--color-text-secondary)] text-sm uppercase tracking-wider mb-6">
+            Where You Fall
+          </h3>
+          <ScoreDistribution score={results.totalCorrect} />
+        </div>
+
+        {/* Item Breakdown Toggle */}
+        <div className="card-premium rounded-lg overflow-hidden mb-8">
+          <button
+            onClick={() => setShowItemBreakdown(!showItemBreakdown)}
+            className="w-full p-6 text-left hover:bg-[var(--color-bg-secondary)]/50 transition-colors duration-200"
+          >
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="text-[var(--color-text-primary)] font-medium mb-1">
+                  Item-by-Item Breakdown
+                </h3>
+                <p className="text-[var(--color-text-muted)] text-sm">
+                  See which items you got correct and incorrect
+                </p>
+              </div>
+              <svg
+                className={`w-5 h-5 text-[var(--color-text-muted)] transition-transform duration-200 ${
+                  showItemBreakdown ? 'rotate-180' : ''
+                }`}
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M19 9l-7 7-7-7"
+                />
+              </svg>
+            </div>
+          </button>
+
+          {showItemBreakdown && (
+            <div className="border-t border-[var(--color-border)] p-6">
+              <div className="grid gap-2">
+                {results.itemResults.map((item) => (
+                  <div
+                    key={item.itemId}
+                    className={`flex items-center justify-between p-3 rounded-lg ${
+                      item.correct
+                        ? 'bg-green-500/10 border border-green-500/20'
+                        : 'bg-red-500/10 border border-red-500/20'
+                    }`}
+                  >
+                    <div className="flex items-center gap-3">
+                      <span className="text-[var(--color-text-muted)] text-sm w-8">
+                        #{item.itemId}
+                      </span>
+                      <span
+                        className={`text-sm ${
+                          item.correct ? 'text-green-400' : 'text-red-400'
+                        }`}
+                      >
+                        {item.correct ? 'Correct' : 'Incorrect'}
+                      </span>
+                    </div>
+                    <div className="text-right">
+                      {!item.correct && (
+                        <div className="text-[var(--color-text-muted)] text-xs">
+                          <span className="line-through opacity-50">
+                            {item.selectedAnswer}
+                          </span>
+                          {' → '}
+                          <span className="text-green-400 capitalize">
+                            {item.correctAnswer}
+                          </span>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* About the Test */}
+        <div className="card-premium rounded-lg p-8 mb-8">
+          <h3 className="text-[var(--color-text-secondary)] text-sm uppercase tracking-wider mb-4">
+            About This Test
+          </h3>
+          <p className="text-[var(--color-text-muted)] text-sm leading-relaxed mb-4">
+            The Reading the Mind in the Eyes Test (RMET) measures &quot;theory of
+            mind&quot; - the ability to understand what others are thinking or feeling
+            based on their eye expressions. It was developed by Baron-Cohen and
+            colleagues at the Autism Research Centre.
+          </p>
+          <p className="text-[var(--color-text-muted)] text-sm leading-relaxed">
+            Normative data: In the general population, the average score is around
+            26 out of 36 (SD ≈ 3.6). Scores can be influenced by factors like
+            attention, vocabulary, and cultural background.
+          </p>
+        </div>
+
+        {/* Citation */}
+        <div className="text-center mb-8">
+          <p className="text-[var(--color-text-muted)] text-xs leading-relaxed">
+            Baron-Cohen, S., Wheelwright, S., Hill, J., Raste, Y., & Plumb, I.
+            (2001). The &quot;Reading the Mind in the Eyes&quot; Test Revised Version: A
+            Study with Normal Adults, and Adults with Asperger Syndrome or
+            High-functioning Autism.{' '}
+            <em>Journal of Child Psychology and Psychiatry</em>, 42(2), 241-251.
+          </p>
+        </div>
+
+        {/* Actions */}
+        <div className="flex flex-col sm:flex-row gap-4 justify-center">
+          <button
+            onClick={() => navigate('/test/rmet')}
+            className="btn-ghost px-8 py-3 rounded text-sm tracking-widest uppercase"
+          >
+            Retake Test
+          </button>
+          <Link
+            to="/"
+            className="btn-gold px-8 py-3 rounded text-sm tracking-widest uppercase text-center"
+          >
+            Explore More Tests
+          </Link>
+        </div>
+
+        {/* Disclaimer */}
+        <div className="mt-12 text-center">
+          <p className="text-[var(--color-text-muted)] text-xs leading-relaxed max-w-2xl mx-auto">
+            This assessment provides insight into social cognition abilities but
+            should not be used for clinical diagnosis. Many factors can influence
+            test performance. Consult a qualified professional for clinical
+            evaluation.
+          </p>
+        </div>
+      </main>
+    </div>
+  );
+}
+
+function Header() {
+  return (
+    <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
+      <div className="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
+        <Link
+          to="/"
+          className="font-display text-2xl font-semibold tracking-wide text-gold-gradient"
+        >
+          Mesearch
+        </Link>
+      </div>
+    </header>
+  );
+}
+
+interface ScoreCircleProps {
+  score: number;
+  total: number;
+  percentile: number;
+}
+
+function ScoreCircle({ score, total, percentile }: ScoreCircleProps) {
+  const percentage = (score / total) * 100;
+  const circumference = 2 * Math.PI * 45;
+  const strokeDashoffset = circumference - (percentage / 100) * circumference;
+
+  // Color based on percentile
+  const getColor = () => {
+    if (percentile >= 70) return 'var(--color-champagne)';
+    if (percentile >= 30) return 'var(--color-gold)';
+    return 'var(--color-text-muted)';
+  };
+
+  return (
+    <div className="relative w-40 h-40">
+      <svg className="w-full h-full -rotate-90">
+        {/* Background circle */}
+        <circle
+          cx="80"
+          cy="80"
+          r="45"
+          fill="none"
+          stroke="var(--color-border)"
+          strokeWidth="8"
+        />
+        {/* Progress circle */}
+        <circle
+          cx="80"
+          cy="80"
+          r="45"
+          fill="none"
+          stroke={getColor()}
+          strokeWidth="8"
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          strokeDashoffset={strokeDashoffset}
+          className="transition-all duration-1000 ease-out"
+        />
+      </svg>
+      {/* Score text */}
+      <div className="absolute inset-0 flex flex-col items-center justify-center">
+        <span className="text-3xl font-display font-medium text-[var(--color-text-primary)]">
+          {score}
+        </span>
+        <span className="text-[var(--color-text-muted)] text-sm">of {total}</span>
+      </div>
+    </div>
+  );
+}
+
+interface ScoreDistributionProps {
+  score: number;
+}
+
+function ScoreDistribution({ score }: ScoreDistributionProps) {
+  // Approximate normal distribution for visualization
+  // Mean = 26.2, SD = 3.6
+  const mean = 26.2;
+  const sd = 3.6;
+
+  // Generate distribution points
+  const points: { x: number; y: number }[] = [];
+  for (let x = 10; x <= 36; x++) {
+    const z = (x - mean) / sd;
+    const y = Math.exp(-0.5 * z * z);
+    points.push({ x, y });
+  }
+
+  const maxY = Math.max(...points.map((p) => p.y));
+  const width = 400;
+  const height = 100;
+  const padding = 20;
+
+  const scaleX = (x: number) =>
+    padding + ((x - 10) / (36 - 10)) * (width - 2 * padding);
+  const scaleY = (y: number) => height - padding - (y / maxY) * (height - 2 * padding);
+
+  const pathD = points
+    .map((p, i) => `${i === 0 ? 'M' : 'L'} ${scaleX(p.x)} ${scaleY(p.y)}`)
+    .join(' ');
+
+  // Close the path for fill
+  const areaPath = `${pathD} L ${scaleX(36)} ${height - padding} L ${scaleX(10)} ${height - padding} Z`;
+
+  return (
+    <div className="w-full overflow-x-auto">
+      <svg
+        viewBox={`0 0 ${width} ${height + 30}`}
+        className="w-full max-w-md mx-auto"
+      >
+        {/* Distribution curve fill */}
+        <path
+          d={areaPath}
+          fill="var(--color-champagne)"
+          fillOpacity="0.1"
+        />
+        {/* Distribution curve line */}
+        <path
+          d={pathD}
+          fill="none"
+          stroke="var(--color-champagne)"
+          strokeWidth="2"
+          opacity="0.5"
+        />
+        {/* Your score marker */}
+        <line
+          x1={scaleX(score)}
+          y1={height - padding}
+          x2={scaleX(score)}
+          y2={padding}
+          stroke="var(--color-champagne)"
+          strokeWidth="2"
+          strokeDasharray="4 4"
+        />
+        <circle
+          cx={scaleX(score)}
+          cy={scaleY(
+            points.find((p) => Math.round(p.x) === score)?.y || 0.5
+          )}
+          r="6"
+          fill="var(--color-champagne)"
+        />
+        {/* Labels */}
+        <text
+          x={scaleX(10)}
+          y={height}
+          textAnchor="middle"
+          className="fill-[var(--color-text-muted)] text-xs"
+        >
+          10
+        </text>
+        <text
+          x={scaleX(20)}
+          y={height}
+          textAnchor="middle"
+          className="fill-[var(--color-text-muted)] text-xs"
+        >
+          20
+        </text>
+        <text
+          x={scaleX(mean)}
+          y={height}
+          textAnchor="middle"
+          className="fill-[var(--color-text-muted)] text-xs"
+        >
+          Mean
+        </text>
+        <text
+          x={scaleX(36)}
+          y={height}
+          textAnchor="middle"
+          className="fill-[var(--color-text-muted)] text-xs"
+        >
+          36
+        </text>
+        <text
+          x={scaleX(score)}
+          y={height + 20}
+          textAnchor="middle"
+          className="fill-[var(--color-champagne)] text-xs font-medium"
+        >
+          You
+        </text>
+      </svg>
+    </div>
+  );
+}

--- a/frontend/data/rmet-items.ts
+++ b/frontend/data/rmet-items.ts
@@ -1,0 +1,339 @@
+// Reading the Mind in the Eyes Test (RMET) Items
+// Source: Baron-Cohen, S., Wheelwright, S., Hill, J., Raste, Y., & Plumb, I. (2001).
+// The "Reading the Mind in the Eyes" Test Revised Version: A Study with Normal Adults,
+// and Adults with Asperger Syndrome or High-functioning Autism.
+// Journal of Child Psychology and Psychiatry, 42(2), 241-251.
+//
+// IMPORTANT: The original RMET images are copyrighted and require permission
+// from the Autism Research Centre for use. This implementation uses placeholder
+// image URLs that should be replaced with properly licensed images.
+//
+// Options for image sourcing:
+// 1. Request permission from Autism Research Centre (https://www.autismresearchcentre.com/)
+// 2. Use Multiracial RMET (MRMET) stimuli with appropriate permissions
+// 3. Create or license original eye photographs
+
+export interface RMETItem {
+  id: number;
+  imageUrl: string;
+  options: string[];
+  correctAnswer: string;
+  definitions?: Record<string, string>;
+}
+
+// Vocabulary definitions for difficult/uncommon words
+export const vocabularyDefinitions: Record<string, string> = {
+  aghast: 'Filled with horror or shock',
+  contemplative: 'Deep in thought; meditative',
+  despondent: 'In low spirits from loss of hope or courage',
+  dispirited: 'Having lost enthusiasm and hope; disheartened',
+  fantasizing: 'Indulging in daydreaming or imagining',
+  flustered: 'Agitated or confused',
+  imploring: 'Making an earnest or desperate appeal',
+  incredulous: 'Unwilling or unable to believe something',
+  pensive: 'Engaged in deep or serious thought',
+  preoccupied: 'Absorbed in thought; distracted',
+  reflective: 'Relating to or characterized by deep thought',
+  sarcastic: 'Using irony to mock or convey contempt',
+  skeptical: 'Not easily convinced; having doubts',
+  tentative: 'Uncertain; hesitant',
+  distrustful: 'Feeling or showing distrust of someone or something',
+  defiant: 'Showing open resistance or bold disobedience',
+  baffled: 'Totally bewildered or perplexed',
+};
+
+// Placeholder image base URL - in production, replace with actual licensed images
+// Using a placeholder service for development/testing
+const IMAGE_BASE_URL = '/images/rmet';
+
+// 36 RMET items (plus practice item)
+// Item 0 is the practice item, Items 1-36 are scored
+export const rmetItems: RMETItem[] = [
+  // Practice item (not scored)
+  {
+    id: 0,
+    imageUrl: `${IMAGE_BASE_URL}/practice.jpg`,
+    options: ['jealous', 'panicked', 'arrogant', 'hateful'],
+    correctAnswer: 'panicked',
+  },
+  // Scored items 1-36
+  {
+    id: 1,
+    imageUrl: `${IMAGE_BASE_URL}/01.jpg`,
+    options: ['playful', 'comforting', 'irritated', 'bored'],
+    correctAnswer: 'playful',
+  },
+  {
+    id: 2,
+    imageUrl: `${IMAGE_BASE_URL}/02.jpg`,
+    options: ['terrified', 'upset', 'arrogant', 'annoyed'],
+    correctAnswer: 'upset',
+  },
+  {
+    id: 3,
+    imageUrl: `${IMAGE_BASE_URL}/03.jpg`,
+    options: ['joking', 'flustered', 'desire', 'convinced'],
+    correctAnswer: 'desire',
+    definitions: { flustered: vocabularyDefinitions.flustered },
+  },
+  {
+    id: 4,
+    imageUrl: `${IMAGE_BASE_URL}/04.jpg`,
+    options: ['joking', 'insisting', 'amused', 'relaxed'],
+    correctAnswer: 'insisting',
+  },
+  {
+    id: 5,
+    imageUrl: `${IMAGE_BASE_URL}/05.jpg`,
+    options: ['irritated', 'sarcastic', 'worried', 'friendly'],
+    correctAnswer: 'worried',
+    definitions: { sarcastic: vocabularyDefinitions.sarcastic },
+  },
+  {
+    id: 6,
+    imageUrl: `${IMAGE_BASE_URL}/06.jpg`,
+    options: ['aghast', 'fantasizing', 'impatient', 'alarmed'],
+    correctAnswer: 'fantasizing',
+    definitions: {
+      aghast: vocabularyDefinitions.aghast,
+      fantasizing: vocabularyDefinitions.fantasizing,
+    },
+  },
+  {
+    id: 7,
+    imageUrl: `${IMAGE_BASE_URL}/07.jpg`,
+    options: ['apologetic', 'friendly', 'uneasy', 'dispirited'],
+    correctAnswer: 'uneasy',
+    definitions: { dispirited: vocabularyDefinitions.dispirited },
+  },
+  {
+    id: 8,
+    imageUrl: `${IMAGE_BASE_URL}/08.jpg`,
+    options: ['despondent', 'relieved', 'shy', 'excited'],
+    correctAnswer: 'despondent',
+    definitions: { despondent: vocabularyDefinitions.despondent },
+  },
+  {
+    id: 9,
+    imageUrl: `${IMAGE_BASE_URL}/09.jpg`,
+    options: ['annoyed', 'hostile', 'horrified', 'preoccupied'],
+    correctAnswer: 'preoccupied',
+    definitions: { preoccupied: vocabularyDefinitions.preoccupied },
+  },
+  {
+    id: 10,
+    imageUrl: `${IMAGE_BASE_URL}/10.jpg`,
+    options: ['cautious', 'insisting', 'bored', 'aghast'],
+    correctAnswer: 'cautious',
+    definitions: { aghast: vocabularyDefinitions.aghast },
+  },
+  {
+    id: 11,
+    imageUrl: `${IMAGE_BASE_URL}/11.jpg`,
+    options: ['terrified', 'amused', 'regretful', 'flirtatious'],
+    correctAnswer: 'regretful',
+  },
+  {
+    id: 12,
+    imageUrl: `${IMAGE_BASE_URL}/12.jpg`,
+    options: ['indifferent', 'embarrassed', 'skeptical', 'dispirited'],
+    correctAnswer: 'skeptical',
+    definitions: {
+      skeptical: vocabularyDefinitions.skeptical,
+      dispirited: vocabularyDefinitions.dispirited,
+    },
+  },
+  {
+    id: 13,
+    imageUrl: `${IMAGE_BASE_URL}/13.jpg`,
+    options: ['decisive', 'anticipating', 'threatening', 'shy'],
+    correctAnswer: 'anticipating',
+  },
+  {
+    id: 14,
+    imageUrl: `${IMAGE_BASE_URL}/14.jpg`,
+    options: ['irritated', 'disappointed', 'depressed', 'accusing'],
+    correctAnswer: 'accusing',
+  },
+  {
+    id: 15,
+    imageUrl: `${IMAGE_BASE_URL}/15.jpg`,
+    options: ['contemplative', 'flustered', 'encouraging', 'amused'],
+    correctAnswer: 'contemplative',
+    definitions: {
+      contemplative: vocabularyDefinitions.contemplative,
+      flustered: vocabularyDefinitions.flustered,
+    },
+  },
+  {
+    id: 16,
+    imageUrl: `${IMAGE_BASE_URL}/16.jpg`,
+    options: ['irritated', 'thoughtful', 'encouraging', 'sympathetic'],
+    correctAnswer: 'thoughtful',
+  },
+  {
+    id: 17,
+    imageUrl: `${IMAGE_BASE_URL}/17.jpg`,
+    options: ['doubtful', 'affectionate', 'playful', 'aghast'],
+    correctAnswer: 'doubtful',
+    definitions: { aghast: vocabularyDefinitions.aghast },
+  },
+  {
+    id: 18,
+    imageUrl: `${IMAGE_BASE_URL}/18.jpg`,
+    options: ['decisive', 'amused', 'aghast', 'bored'],
+    correctAnswer: 'decisive',
+    definitions: { aghast: vocabularyDefinitions.aghast },
+  },
+  {
+    id: 19,
+    imageUrl: `${IMAGE_BASE_URL}/19.jpg`,
+    options: ['arrogant', 'grateful', 'sarcastic', 'tentative'],
+    correctAnswer: 'tentative',
+    definitions: {
+      sarcastic: vocabularyDefinitions.sarcastic,
+      tentative: vocabularyDefinitions.tentative,
+    },
+  },
+  {
+    id: 20,
+    imageUrl: `${IMAGE_BASE_URL}/20.jpg`,
+    options: ['dominant', 'friendly', 'guilty', 'horrified'],
+    correctAnswer: 'friendly',
+  },
+  {
+    id: 21,
+    imageUrl: `${IMAGE_BASE_URL}/21.jpg`,
+    options: ['embarrassed', 'fantasizing', 'confused', 'panicked'],
+    correctAnswer: 'fantasizing',
+    definitions: { fantasizing: vocabularyDefinitions.fantasizing },
+  },
+  {
+    id: 22,
+    imageUrl: `${IMAGE_BASE_URL}/22.jpg`,
+    options: ['preoccupied', 'grateful', 'insisting', 'imploring'],
+    correctAnswer: 'preoccupied',
+    definitions: {
+      preoccupied: vocabularyDefinitions.preoccupied,
+      imploring: vocabularyDefinitions.imploring,
+    },
+  },
+  {
+    id: 23,
+    imageUrl: `${IMAGE_BASE_URL}/23.jpg`,
+    options: ['contented', 'apologetic', 'defiant', 'curious'],
+    correctAnswer: 'defiant',
+    definitions: { defiant: vocabularyDefinitions.defiant },
+  },
+  {
+    id: 24,
+    imageUrl: `${IMAGE_BASE_URL}/24.jpg`,
+    options: ['pensive', 'irritated', 'excited', 'hostile'],
+    correctAnswer: 'pensive',
+    definitions: { pensive: vocabularyDefinitions.pensive },
+  },
+  {
+    id: 25,
+    imageUrl: `${IMAGE_BASE_URL}/25.jpg`,
+    options: ['panicked', 'incredulous', 'despondent', 'interested'],
+    correctAnswer: 'interested',
+    definitions: {
+      incredulous: vocabularyDefinitions.incredulous,
+      despondent: vocabularyDefinitions.despondent,
+    },
+  },
+  {
+    id: 26,
+    imageUrl: `${IMAGE_BASE_URL}/26.jpg`,
+    options: ['alarmed', 'shy', 'hostile', 'anxious'],
+    correctAnswer: 'hostile',
+  },
+  {
+    id: 27,
+    imageUrl: `${IMAGE_BASE_URL}/27.jpg`,
+    options: ['joking', 'cautious', 'arrogant', 'reassuring'],
+    correctAnswer: 'cautious',
+  },
+  {
+    id: 28,
+    imageUrl: `${IMAGE_BASE_URL}/28.jpg`,
+    options: ['interested', 'joking', 'affectionate', 'contented'],
+    correctAnswer: 'interested',
+  },
+  {
+    id: 29,
+    imageUrl: `${IMAGE_BASE_URL}/29.jpg`,
+    options: ['impatient', 'aghast', 'irritated', 'reflective'],
+    correctAnswer: 'reflective',
+    definitions: {
+      aghast: vocabularyDefinitions.aghast,
+      reflective: vocabularyDefinitions.reflective,
+    },
+  },
+  {
+    id: 30,
+    imageUrl: `${IMAGE_BASE_URL}/30.jpg`,
+    options: ['grateful', 'flirtatious', 'hostile', 'disappointed'],
+    correctAnswer: 'flirtatious',
+  },
+  {
+    id: 31,
+    imageUrl: `${IMAGE_BASE_URL}/31.jpg`,
+    options: ['ashamed', 'confident', 'joking', 'dispirited'],
+    correctAnswer: 'confident',
+    definitions: { dispirited: vocabularyDefinitions.dispirited },
+  },
+  {
+    id: 32,
+    imageUrl: `${IMAGE_BASE_URL}/32.jpg`,
+    options: ['serious', 'ashamed', 'bewildered', 'alarmed'],
+    correctAnswer: 'serious',
+  },
+  {
+    id: 33,
+    imageUrl: `${IMAGE_BASE_URL}/33.jpg`,
+    options: ['embarrassed', 'guilty', 'fantasizing', 'concerned'],
+    correctAnswer: 'concerned',
+    definitions: { fantasizing: vocabularyDefinitions.fantasizing },
+  },
+  {
+    id: 34,
+    imageUrl: `${IMAGE_BASE_URL}/34.jpg`,
+    options: ['aghast', 'baffled', 'distrustful', 'terrified'],
+    correctAnswer: 'distrustful',
+    definitions: {
+      aghast: vocabularyDefinitions.aghast,
+      baffled: vocabularyDefinitions.baffled,
+      distrustful: vocabularyDefinitions.distrustful,
+    },
+  },
+  {
+    id: 35,
+    imageUrl: `${IMAGE_BASE_URL}/35.jpg`,
+    options: ['puzzled', 'nervous', 'insisting', 'contemplative'],
+    correctAnswer: 'nervous',
+    definitions: { contemplative: vocabularyDefinitions.contemplative },
+  },
+  {
+    id: 36,
+    imageUrl: `${IMAGE_BASE_URL}/36.jpg`,
+    options: ['ashamed', 'nervous', 'suspicious', 'indecisive'],
+    correctAnswer: 'suspicious',
+  },
+];
+
+// Get scored items only (excludes practice item)
+export const scoredItems = rmetItems.filter((item) => item.id > 0);
+
+// Get practice item
+export const practiceItem = rmetItems.find((item) => item.id === 0)!;
+
+// Get definition for a word if it exists
+export function getDefinition(word: string): string | undefined {
+  return vocabularyDefinitions[word.toLowerCase()];
+}
+
+// Check if a word has a definition available
+export function hasDefinition(word: string): boolean {
+  return word.toLowerCase() in vocabularyDefinitions;
+}

--- a/frontend/data/rmet-scoring.test.ts
+++ b/frontend/data/rmet-scoring.test.ts
@@ -1,0 +1,331 @@
+// Unit tests for RMET scoring logic
+import { describe, it, expect } from 'vitest';
+import {
+  isCorrect,
+  calculateItemResult,
+  calculatePercentile,
+  getInterpretation,
+  getScoreLevel,
+  calculateResults,
+  serializeResults,
+  deserializeResults,
+  serializeResponses,
+  deserializeResponses,
+  type RMETResponse,
+} from './rmet-scoring';
+import {
+  rmetItems,
+  scoredItems,
+  practiceItem,
+  getDefinition,
+  hasDefinition,
+  vocabularyDefinitions,
+} from './rmet-items';
+
+describe('RMET Items Data Integrity', () => {
+  it('has 37 items total (1 practice + 36 scored)', () => {
+    expect(rmetItems.length).toBe(37);
+  });
+
+  it('has 36 scored items', () => {
+    expect(scoredItems.length).toBe(36);
+  });
+
+  it('has 1 practice item with id 0', () => {
+    expect(practiceItem).toBeDefined();
+    expect(practiceItem.id).toBe(0);
+  });
+
+  it('scored items have ids 1-36', () => {
+    const ids = scoredItems.map((item) => item.id);
+    for (let i = 1; i <= 36; i++) {
+      expect(ids).toContain(i);
+    }
+  });
+
+  it('each item has exactly 4 options', () => {
+    for (const item of rmetItems) {
+      expect(item.options.length).toBe(4);
+    }
+  });
+
+  it('each item has a correct answer in its options', () => {
+    for (const item of rmetItems) {
+      const correctInOptions = item.options.some(
+        (opt) => opt.toLowerCase() === item.correctAnswer.toLowerCase()
+      );
+      expect(correctInOptions).toBe(true);
+    }
+  });
+
+  it('has unique item IDs', () => {
+    const ids = rmetItems.map((item) => item.id);
+    const uniqueIds = new Set(ids);
+    expect(uniqueIds.size).toBe(rmetItems.length);
+  });
+});
+
+describe('Vocabulary Definitions', () => {
+  it('has definitions for difficult words', () => {
+    expect(Object.keys(vocabularyDefinitions).length).toBeGreaterThan(0);
+  });
+
+  it('getDefinition returns definition for known word', () => {
+    expect(getDefinition('aghast')).toBe('Filled with horror or shock');
+    expect(getDefinition('contemplative')).toBe('Deep in thought; meditative');
+  });
+
+  it('getDefinition returns undefined for unknown word', () => {
+    expect(getDefinition('happy')).toBeUndefined();
+    expect(getDefinition('unknown')).toBeUndefined();
+  });
+
+  it('getDefinition is case-insensitive', () => {
+    expect(getDefinition('AGHAST')).toBe(getDefinition('aghast'));
+    expect(getDefinition('Contemplative')).toBe(getDefinition('contemplative'));
+  });
+
+  it('hasDefinition returns true for known words', () => {
+    expect(hasDefinition('aghast')).toBe(true);
+    expect(hasDefinition('contemplative')).toBe(true);
+  });
+
+  it('hasDefinition returns false for unknown words', () => {
+    expect(hasDefinition('happy')).toBe(false);
+    expect(hasDefinition('unknown')).toBe(false);
+  });
+
+  it('hasDefinition is case-insensitive', () => {
+    expect(hasDefinition('AGHAST')).toBe(true);
+    expect(hasDefinition('Contemplative')).toBe(true);
+  });
+});
+
+describe('RMET Scoring', () => {
+  describe('isCorrect', () => {
+    it('returns true for correct answer', () => {
+      const item = scoredItems[0]; // id: 1, correctAnswer: 'playful'
+      expect(isCorrect(item, 'playful')).toBe(true);
+    });
+
+    it('returns false for incorrect answer', () => {
+      const item = scoredItems[0];
+      expect(isCorrect(item, 'bored')).toBe(false);
+    });
+
+    it('is case-insensitive', () => {
+      const item = scoredItems[0];
+      expect(isCorrect(item, 'PLAYFUL')).toBe(true);
+      expect(isCorrect(item, 'Playful')).toBe(true);
+    });
+  });
+
+  describe('calculateItemResult', () => {
+    it('marks correct answer as correct', () => {
+      const item = scoredItems[0];
+      const response: RMETResponse = {
+        itemId: item.id,
+        selectedAnswer: item.correctAnswer,
+      };
+
+      const result = calculateItemResult(item, response);
+      expect(result.correct).toBe(true);
+      expect(result.selectedAnswer).toBe(item.correctAnswer);
+      expect(result.correctAnswer).toBe(item.correctAnswer);
+    });
+
+    it('marks incorrect answer as incorrect', () => {
+      const item = scoredItems[0];
+      const wrongAnswer = item.options.find((opt) => opt !== item.correctAnswer)!;
+      const response: RMETResponse = {
+        itemId: item.id,
+        selectedAnswer: wrongAnswer,
+      };
+
+      const result = calculateItemResult(item, response);
+      expect(result.correct).toBe(false);
+    });
+
+    it('includes response time when provided', () => {
+      const item = scoredItems[0];
+      const response: RMETResponse = {
+        itemId: item.id,
+        selectedAnswer: item.correctAnswer,
+        responseTime: 5000,
+      };
+
+      const result = calculateItemResult(item, response);
+      expect(result.responseTime).toBe(5000);
+    });
+  });
+
+  describe('calculatePercentile', () => {
+    it('returns percentile between 0 and 100', () => {
+      for (let score = 0; score <= 36; score++) {
+        const percentile = calculatePercentile(score);
+        expect(percentile).toBeGreaterThanOrEqual(0);
+        expect(percentile).toBeLessThanOrEqual(100);
+      }
+    });
+
+    it('returns higher percentile for higher scores', () => {
+      const lowPercentile = calculatePercentile(15);
+      const midPercentile = calculatePercentile(26);
+      const highPercentile = calculatePercentile(32);
+
+      expect(midPercentile).toBeGreaterThan(lowPercentile);
+      expect(highPercentile).toBeGreaterThan(midPercentile);
+    });
+
+    it('returns ~50th percentile for mean score (26)', () => {
+      const percentile = calculatePercentile(26);
+      expect(percentile).toBeGreaterThanOrEqual(45);
+      expect(percentile).toBeLessThanOrEqual(55);
+    });
+  });
+
+  describe('getInterpretation', () => {
+    it('returns above-average interpretation for high scores', () => {
+      const interpretation = getInterpretation(32);
+      expect(interpretation.toLowerCase()).toContain('above-average');
+    });
+
+    it('returns typical range interpretation for average scores', () => {
+      const interpretation = getInterpretation(26);
+      expect(interpretation.toLowerCase()).toContain('typical');
+    });
+
+    it('returns below range interpretation for low scores', () => {
+      const interpretation = getInterpretation(15);
+      expect(interpretation.toLowerCase()).toContain('below');
+    });
+
+    it('returns notably below interpretation for very low scores', () => {
+      const interpretation = getInterpretation(10);
+      expect(interpretation.toLowerCase()).toContain('notably below');
+    });
+  });
+
+  describe('getScoreLevel', () => {
+    it('returns correct level labels', () => {
+      expect(getScoreLevel(32)).toBe('High');
+      expect(getScoreLevel(28)).toBe('Above Average');
+      expect(getScoreLevel(24)).toBe('Average');
+      expect(getScoreLevel(19)).toBe('Below Average');
+      expect(getScoreLevel(10)).toBe('Low');
+    });
+  });
+
+  describe('calculateResults', () => {
+    it('returns correct results for all correct answers', () => {
+      const responses: RMETResponse[] = scoredItems.map((item) => ({
+        itemId: item.id,
+        selectedAnswer: item.correctAnswer,
+      }));
+
+      const results = calculateResults(responses);
+      expect(results.totalCorrect).toBe(36);
+      expect(results.totalQuestions).toBe(36);
+      expect(results.percentCorrect).toBe(100);
+      expect(results.completedAt).toBeDefined();
+    });
+
+    it('returns correct results for all wrong answers', () => {
+      const responses: RMETResponse[] = scoredItems.map((item) => ({
+        itemId: item.id,
+        selectedAnswer: item.options.find((opt) => opt !== item.correctAnswer)!,
+      }));
+
+      const results = calculateResults(responses);
+      expect(results.totalCorrect).toBe(0);
+      expect(results.percentCorrect).toBe(0);
+    });
+
+    it('calculates average response time when provided', () => {
+      const responses: RMETResponse[] = scoredItems.map((item) => ({
+        itemId: item.id,
+        selectedAnswer: item.correctAnswer,
+        responseTime: 3000,
+      }));
+
+      const results = calculateResults(responses);
+      expect(results.averageResponseTime).toBe(3000);
+    });
+
+    it('handles mixed response times', () => {
+      const responses: RMETResponse[] = scoredItems.map((item, i) => ({
+        itemId: item.id,
+        selectedAnswer: item.correctAnswer,
+        responseTime: i < 10 ? 2000 : undefined,
+      }));
+
+      const results = calculateResults(responses);
+      expect(results.averageResponseTime).toBe(2000);
+    });
+
+    it('returns undefined average time when no times provided', () => {
+      const responses: RMETResponse[] = scoredItems.slice(0, 5).map((item) => ({
+        itemId: item.id,
+        selectedAnswer: item.correctAnswer,
+      }));
+
+      const results = calculateResults(responses);
+      expect(results.averageResponseTime).toBeUndefined();
+    });
+
+    it('includes all item results', () => {
+      const responses: RMETResponse[] = scoredItems.map((item) => ({
+        itemId: item.id,
+        selectedAnswer: item.correctAnswer,
+      }));
+
+      const results = calculateResults(responses);
+      expect(results.itemResults.length).toBe(36);
+    });
+  });
+});
+
+describe('Serialization', () => {
+  describe('serializeResults / deserializeResults', () => {
+    it('round-trips results correctly', () => {
+      const responses: RMETResponse[] = scoredItems.slice(0, 10).map((item) => ({
+        itemId: item.id,
+        selectedAnswer: item.correctAnswer,
+        responseTime: 3000,
+      }));
+      const results = calculateResults(responses);
+
+      const serialized = serializeResults(results);
+      const deserialized = deserializeResults(serialized);
+
+      expect(deserialized).not.toBeNull();
+      expect(deserialized?.totalCorrect).toBe(results.totalCorrect);
+      expect(deserialized?.totalQuestions).toBe(results.totalQuestions);
+      expect(deserialized?.itemResults.length).toBe(results.itemResults.length);
+    });
+
+    it('returns null for invalid JSON', () => {
+      expect(deserializeResults('invalid json')).toBeNull();
+      expect(deserializeResults('{broken')).toBeNull();
+    });
+  });
+
+  describe('serializeResponses / deserializeResponses', () => {
+    it('round-trips responses correctly', () => {
+      const responses: RMETResponse[] = [
+        { itemId: 1, selectedAnswer: 'playful' },
+        { itemId: 2, selectedAnswer: 'upset', responseTime: 5000 },
+        { itemId: 3, selectedAnswer: 'desire' },
+      ];
+
+      const serialized = serializeResponses(responses);
+      const deserialized = deserializeResponses(serialized);
+
+      expect(deserialized).toEqual(responses);
+    });
+
+    it('returns null for invalid JSON', () => {
+      expect(deserializeResponses('invalid json')).toBeNull();
+    });
+  });
+});

--- a/frontend/data/rmet-scoring.ts
+++ b/frontend/data/rmet-scoring.ts
@@ -1,0 +1,180 @@
+// RMET Scoring Logic
+// Based on Baron-Cohen et al. (2001)
+// Reference: Baron-Cohen, S., Wheelwright, S., Hill, J., Raste, Y., & Plumb, I. (2001).
+// The "Reading the Mind in the Eyes" Test Revised Version.
+// Journal of Child Psychology and Psychiatry, 42(2), 241-251.
+
+import { type RMETItem, scoredItems } from './rmet-items';
+
+export interface RMETResponse {
+  itemId: number;
+  selectedAnswer: string;
+  responseTime?: number; // milliseconds
+}
+
+export interface RMETItemResult {
+  itemId: number;
+  selectedAnswer: string;
+  correctAnswer: string;
+  correct: boolean;
+  responseTime?: number;
+}
+
+export interface RMETResults {
+  totalCorrect: number;
+  totalQuestions: number;
+  percentCorrect: number;
+  percentile: number;
+  interpretation: string;
+  itemResults: RMETItemResult[];
+  averageResponseTime?: number;
+  completedAt: string;
+}
+
+// Check if a response is correct
+export function isCorrect(item: RMETItem, selectedAnswer: string): boolean {
+  return selectedAnswer.toLowerCase() === item.correctAnswer.toLowerCase();
+}
+
+// Calculate item result
+export function calculateItemResult(
+  item: RMETItem,
+  response: RMETResponse
+): RMETItemResult {
+  return {
+    itemId: item.id,
+    selectedAnswer: response.selectedAnswer,
+    correctAnswer: item.correctAnswer,
+    correct: isCorrect(item, response.selectedAnswer),
+    responseTime: response.responseTime,
+  };
+}
+
+// Normative data from Baron-Cohen et al. (2001)
+// General population: Mean = 26.2, SD = 3.6
+// These norms are used to calculate percentiles
+const NORM_MEAN = 26.2;
+const NORM_SD = 3.6;
+
+// Convert z-score to percentile using standard normal CDF approximation
+function zToPercentile(z: number): number {
+  // Approximation of the standard normal CDF
+  const a1 = 0.254829592;
+  const a2 = -0.284496736;
+  const a3 = 1.421413741;
+  const a4 = -1.453152027;
+  const a5 = 1.061405429;
+  const p = 0.3275911;
+
+  const sign = z < 0 ? -1 : 1;
+  const absZ = Math.abs(z);
+
+  const t = 1.0 / (1.0 + p * absZ);
+  const y =
+    1.0 -
+    ((((a5 * t + a4) * t + a3) * t + a2) * t + a1) * t * Math.exp((-absZ * absZ) / 2);
+
+  const cdf = 0.5 * (1.0 + sign * y);
+  return Math.round(cdf * 100);
+}
+
+// Calculate percentile based on normative data
+export function calculatePercentile(totalCorrect: number): number {
+  const z = (totalCorrect - NORM_MEAN) / NORM_SD;
+  return zToPercentile(z);
+}
+
+// Get interpretation based on score
+export function getInterpretation(totalCorrect: number): string {
+  if (totalCorrect >= 30) {
+    return 'Your score indicates above-average ability to recognize mental states from eye expressions. You may be particularly skilled at reading subtle emotional cues.';
+  }
+  if (totalCorrect >= 22) {
+    return 'Your score falls within the typical range for adults. You demonstrate a normal ability to recognize mental states from eye expressions.';
+  }
+  if (totalCorrect >= 15) {
+    return 'Your score is somewhat below the typical range. This may suggest some difficulty recognizing subtle mental states from eye expressions.';
+  }
+  return 'Your score is notably below the typical range. This pattern is sometimes associated with differences in social cognition, though many factors can influence test performance.';
+}
+
+// Get score level label
+export function getScoreLevel(totalCorrect: number): string {
+  if (totalCorrect >= 30) return 'High';
+  if (totalCorrect >= 26) return 'Above Average';
+  if (totalCorrect >= 22) return 'Average';
+  if (totalCorrect >= 18) return 'Below Average';
+  return 'Low';
+}
+
+// Calculate all results from responses
+export function calculateResults(responses: RMETResponse[]): RMETResults {
+  const itemResults: RMETItemResult[] = [];
+  let totalCorrect = 0;
+  let totalResponseTime = 0;
+  let responsesWithTime = 0;
+
+  for (const response of responses) {
+    const item = scoredItems.find((i) => i.id === response.itemId);
+    if (!item) continue;
+
+    const result = calculateItemResult(item, response);
+    itemResults.push(result);
+
+    if (result.correct) {
+      totalCorrect++;
+    }
+
+    if (response.responseTime !== undefined) {
+      totalResponseTime += response.responseTime;
+      responsesWithTime++;
+    }
+  }
+
+  const totalQuestions = scoredItems.length;
+  const percentCorrect = Math.round((totalCorrect / totalQuestions) * 100);
+  const percentile = calculatePercentile(totalCorrect);
+  const interpretation = getInterpretation(totalCorrect);
+
+  const averageResponseTime =
+    responsesWithTime > 0 ? Math.round(totalResponseTime / responsesWithTime) : undefined;
+
+  return {
+    totalCorrect,
+    totalQuestions,
+    percentCorrect,
+    percentile,
+    interpretation,
+    itemResults,
+    averageResponseTime,
+    completedAt: new Date().toISOString(),
+  };
+}
+
+// Serialize results to JSON for localStorage
+export function serializeResults(results: RMETResults): string {
+  return JSON.stringify(results);
+}
+
+// Deserialize results from JSON
+export function deserializeResults(json: string): RMETResults | null {
+  try {
+    return JSON.parse(json) as RMETResults;
+  } catch {
+    return null;
+  }
+}
+
+// Serialize responses to JSON for localStorage (for pause/resume)
+export function serializeResponses(responses: RMETResponse[]): string {
+  return JSON.stringify(responses);
+}
+
+// Deserialize responses from JSON
+export function deserializeResponses(json: string): RMETResponse[] | null {
+  try {
+    return JSON.parse(json) as RMETResponse[];
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Implements the Reading the Mind in the Eyes Test (RMET), a research-backed assessment measuring theory of mind / social cognition developed by Baron-Cohen et al. (2001).

- 36 test items plus 1 practice item with 4-choice responses
- Vocabulary tooltips for difficult words (aghast, contemplative, etc.)
- Scoring with normative percentiles based on published norms
- SVG placeholder images for development (production needs licensed images)
- Progress saving/resume functionality
- Results visualization with distribution chart

## Technical Changes

- `frontend/data/rmet-items.ts` - All 36 items with options and correct answers
- `frontend/data/rmet-scoring.ts` - Scoring logic and interpretation
- `frontend/data/rmet-scoring.test.ts` - 38 unit tests (all passing)
- `frontend/components/RMETAssessment.tsx` - Assessment UI
- `frontend/components/RMETResults.tsx` - Results display
- `frontend/App.tsx` - Routes and homepage card
- `e2e/rmet.spec.ts` - E2E tests

## Test plan

- [ ] Unit tests pass (`npm run test`)
- [ ] Navigate to /test/rmet and complete assessment
- [ ] Verify practice question appears first
- [ ] Verify vocabulary tooltips on hover
- [ ] Verify progress saves when navigating away
- [ ] Verify results page shows score, percentile, interpretation
- [ ] Verify item-by-item breakdown expands correctly

## Image Licensing Note

The original RMET images are copyrighted by the Autism Research Centre. This implementation uses SVG placeholder images for development. Production deployment will require:
1. Permission from Autism Research Centre, OR
2. Use of alternative public domain eye photographs

Closes #31

---
Generated with [Claude Code](https://claude.com/claude-code)