### PR TITLE
Show full results for all test types in history detail view (closes #44)

### DIFF
--- a/e2e/mini-test.spec.ts
+++ b/e2e/mini-test.spec.ts
@@ -158,8 +158,9 @@ test.describe('Mini-Test Feature Flag', () => {
       // Should see the result detail content
       await expect(page.getByTestId('result-detail-content')).toBeVisible();
 
-      // Should see Mini-Test as the title
-      await expect(page.getByRole('heading', { name: 'Mini-Test' })).toBeVisible();
+      // Should see Result Details as the heading and Mini-Test as the test type label
+      await expect(page.getByRole('heading', { name: 'Result Details' })).toBeVisible();
+      await expect(page.getByText('Mini-Test')).toBeVisible();
 
       // Should see dimension scores
       await expect(page.getByText('Dimension Scores')).toBeVisible();

--- a/frontend/components/BigFiveResults.tsx
+++ b/frontend/components/BigFiveResults.tsx
@@ -11,23 +11,32 @@ import { dimensionInfo, facetInfo, type Dimension } from '../data/big-five-items
 
 const RESULTS_STORAGE_KEY = 'mesearch-bigfive-results';
 
-export default function BigFiveResults() {
+interface BigFiveResultsProps {
+  initialResults?: Results;
+  showHeader?: boolean;
+  showActions?: boolean;
+}
+
+export default function BigFiveResults({ initialResults, showHeader = true, showActions = true }: BigFiveResultsProps) {
   const navigate = useNavigate();
-  const [results, setResults] = useState<Results | null>(null);
+  const [results, setResults] = useState<Results | null>(initialResults || null);
   const [expandedDimension, setExpandedDimension] = useState<Dimension | null>(null);
 
   useEffect(() => {
-    const saved = localStorage.getItem(RESULTS_STORAGE_KEY);
-    if (saved) {
-      const parsed = deserializeResults(saved);
-      setResults(parsed);
+    // Only load from localStorage if no initial results provided
+    if (!initialResults) {
+      const saved = localStorage.getItem(RESULTS_STORAGE_KEY);
+      if (saved) {
+        const parsed = deserializeResults(saved);
+        setResults(parsed);
+      }
     }
-  }, []);
+  }, [initialResults]);
 
   if (!results) {
     return (
-      <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-        <Header />
+      <div className={showHeader ? "min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300" : ""}>
+        {showHeader && <Header />}
         <main className="mx-auto max-w-2xl px-6 py-16 text-center">
           <div className="card-premium rounded-lg p-10">
             <h2 className="font-display text-2xl font-medium text-[var(--color-text-primary)] mb-4">
@@ -51,8 +60,8 @@ export default function BigFiveResults() {
   const dimensionScores = results.dimensions;
 
   return (
-    <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-      <Header />
+    <div className={showHeader ? "min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300" : ""}>
+      {showHeader && <Header />}
       <main className="mx-auto max-w-4xl px-6 py-12">
         {/* Title */}
         <div className="text-center mb-12">
@@ -94,20 +103,22 @@ export default function BigFiveResults() {
         </div>
 
         {/* Actions */}
-        <div className="mt-12 flex flex-col sm:flex-row gap-4 justify-center">
-          <button
-            onClick={() => navigate('/test/big-five')}
-            className="btn-ghost px-8 py-3 rounded text-sm tracking-widest uppercase"
-          >
-            Retake Test
-          </button>
-          <Link
-            to="/"
-            className="btn-gold px-8 py-3 rounded text-sm tracking-widest uppercase text-center"
-          >
-            Explore More Tests
-          </Link>
-        </div>
+        {showActions && (
+          <div className="mt-12 flex flex-col sm:flex-row gap-4 justify-center">
+            <button
+              onClick={() => navigate('/test/big-five')}
+              className="btn-ghost px-8 py-3 rounded text-sm tracking-widest uppercase"
+            >
+              Retake Test
+            </button>
+            <Link
+              to="/"
+              className="btn-gold px-8 py-3 rounded text-sm tracking-widest uppercase text-center"
+            >
+              Explore More Tests
+            </Link>
+          </div>
+        )}
 
         {/* Disclaimer */}
         <div className="mt-12 text-center">
@@ -121,6 +132,9 @@ export default function BigFiveResults() {
     </div>
   );
 }
+
+// Export the Results type for use in ResultDetail
+export type { Results as BigFiveResultsType };
 
 function Header() {
   return (

--- a/frontend/components/ECRResults.tsx
+++ b/frontend/components/ECRResults.tsx
@@ -12,22 +12,31 @@ import {
 
 const RESULTS_STORAGE_KEY = 'mesearch-ecr-results';
 
-export default function ECRResults() {
+interface ECRResultsProps {
+  initialResults?: Results;
+  showHeader?: boolean;
+  showActions?: boolean;
+}
+
+export default function ECRResults({ initialResults, showHeader = true, showActions = true }: ECRResultsProps) {
   const navigate = useNavigate();
-  const [results, setResults] = useState<Results | null>(null);
+  const [results, setResults] = useState<Results | null>(initialResults || null);
 
   useEffect(() => {
-    const saved = localStorage.getItem(RESULTS_STORAGE_KEY);
-    if (saved) {
-      const parsed = deserializeResults(saved);
-      setResults(parsed);
+    // Only load from localStorage if no initial results provided
+    if (!initialResults) {
+      const saved = localStorage.getItem(RESULTS_STORAGE_KEY);
+      if (saved) {
+        const parsed = deserializeResults(saved);
+        setResults(parsed);
+      }
     }
-  }, []);
+  }, [initialResults]);
 
   if (!results) {
     return (
-      <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-        <Header />
+      <div className={showHeader ? "min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300" : ""}>
+        {showHeader && <Header />}
         <main className="mx-auto max-w-2xl px-6 py-16 text-center">
           <div className="card-premium rounded-lg p-10">
             <h2 className="font-display text-2xl font-medium text-[var(--color-text-primary)] mb-4">
@@ -52,8 +61,8 @@ export default function ECRResults() {
   const styleInfo = attachmentStyleInfo[suggestedStyle];
 
   return (
-    <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-      <Header />
+    <div className={showHeader ? "min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300" : ""}>
+      {showHeader && <Header />}
       <main className="mx-auto max-w-4xl px-6 py-12">
         {/* Title */}
         <div className="text-center mb-12">
@@ -199,20 +208,22 @@ export default function ECRResults() {
         </div>
 
         {/* Actions */}
-        <div className="flex flex-col sm:flex-row gap-4 justify-center">
-          <button
-            onClick={() => navigate('/test/ecr')}
-            className="btn-ghost px-8 py-3 rounded text-sm tracking-widest uppercase"
-          >
-            Retake Test
-          </button>
-          <Link
-            to="/"
-            className="btn-gold px-8 py-3 rounded text-sm tracking-widest uppercase text-center"
-          >
-            Explore More Tests
-          </Link>
-        </div>
+        {showActions && (
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <button
+              onClick={() => navigate('/test/ecr')}
+              className="btn-ghost px-8 py-3 rounded text-sm tracking-widest uppercase"
+            >
+              Retake Test
+            </button>
+            <Link
+              to="/"
+              className="btn-gold px-8 py-3 rounded text-sm tracking-widest uppercase text-center"
+            >
+              Explore More Tests
+            </Link>
+          </div>
+        )}
       </main>
     </div>
   );

--- a/frontend/components/EnneagramResults.tsx
+++ b/frontend/components/EnneagramResults.tsx
@@ -5,9 +5,11 @@ import { getTypeById } from '../data/enneagram-types';
 interface EnneagramResultsProps {
   result: EnneagramResult;
   onRetake: () => void;
+  showHeader?: boolean;
+  showActions?: boolean;
 }
 
-export function EnneagramResults({ result, onRetake }: EnneagramResultsProps) {
+export function EnneagramResults({ result, onRetake, showHeader = true, showActions = true }: EnneagramResultsProps) {
   const primaryTypeInfo = getTypeById(result.primaryType);
   const wingTypeInfo = getTypeById(result.wing);
   const sortedScores = sortScoresByPercentage(result.scores);
@@ -161,20 +163,22 @@ export function EnneagramResults({ result, onRetake }: EnneagramResultsProps) {
       </div>
 
       {/* Actions */}
-      <div className="flex flex-col sm:flex-row gap-4 justify-center">
-        <button
-          onClick={onRetake}
-          className="btn-ghost px-8 py-3 rounded text-sm tracking-widest uppercase"
-        >
-          Retake Test
-        </button>
-        <Link
-          to="/"
-          className="btn-gold px-8 py-3 rounded text-sm tracking-widest uppercase text-center"
-        >
-          Explore Other Tests
-        </Link>
-      </div>
+      {showActions && (
+        <div className="flex flex-col sm:flex-row gap-4 justify-center">
+          <button
+            onClick={onRetake}
+            className="btn-ghost px-8 py-3 rounded text-sm tracking-widest uppercase"
+          >
+            Retake Test
+          </button>
+          <Link
+            to="/"
+            className="btn-gold px-8 py-3 rounded text-sm tracking-widest uppercase text-center"
+          >
+            Explore Other Tests
+          </Link>
+        </div>
+      )}
 
       {/* Attribution */}
       <div className="text-center pt-6 border-t border-[var(--color-border-subtle)]">

--- a/frontend/components/HexacoResults.tsx
+++ b/frontend/components/HexacoResults.tsx
@@ -13,6 +13,8 @@ import {
 
 interface HexacoResultsProps {
   scores: DimensionScore[] | null;
+  showHeader?: boolean;
+  showActions?: boolean;
 }
 
 // Dimension colors for visual distinction
@@ -124,7 +126,7 @@ function DimensionCard({ dimensionScore }: { dimensionScore: DimensionScore }) {
   );
 }
 
-export default function HexacoResults({ scores }: HexacoResultsProps) {
+export default function HexacoResults({ scores, showHeader = true, showActions = true }: HexacoResultsProps) {
   // Add noindex meta tag
   useEffect(() => {
     const meta = document.createElement('meta');
@@ -138,17 +140,19 @@ export default function HexacoResults({ scores }: HexacoResultsProps) {
 
   if (!scores) {
     return (
-      <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-        <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
-          <div className="mx-auto max-w-6xl px-6 py-5">
-            <Link
-              to="/"
-              className="font-display text-2xl font-semibold tracking-wide text-gold-gradient"
-            >
-              Mēsearch
-            </Link>
-          </div>
-        </header>
+      <div className={showHeader ? "min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300" : ""}>
+        {showHeader && (
+          <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
+            <div className="mx-auto max-w-6xl px-6 py-5">
+              <Link
+                to="/"
+                className="font-display text-2xl font-semibold tracking-wide text-gold-gradient"
+              >
+                Mēsearch
+              </Link>
+            </div>
+          </header>
+        )}
         <main className="mx-auto max-w-2xl px-6 py-24 text-center">
           <div className="card-premium rounded-lg p-12">
             <p className="text-[var(--color-champagne)] text-xs tracking-[0.3em] uppercase mb-4">
@@ -180,24 +184,26 @@ export default function HexacoResults({ scores }: HexacoResultsProps) {
   });
 
   return (
-    <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
+    <div className={showHeader ? "min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300" : ""}>
       {/* Header */}
-      <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md sticky top-0 z-50 transition-colors duration-300">
-        <div className="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
-          <Link
-            to="/"
-            className="font-display text-2xl font-semibold tracking-wide text-gold-gradient"
-          >
-            Mēsearch
-          </Link>
-          <Link
-            to="/"
-            className="text-[var(--color-text-secondary)] hover:text-[var(--color-champagne)] transition-colors duration-300 text-sm tracking-wide"
-          >
-            Back to Home
-          </Link>
-        </div>
-      </header>
+      {showHeader && (
+        <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md sticky top-0 z-50 transition-colors duration-300">
+          <div className="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
+            <Link
+              to="/"
+              className="font-display text-2xl font-semibold tracking-wide text-gold-gradient"
+            >
+              Mēsearch
+            </Link>
+            <Link
+              to="/"
+              className="text-[var(--color-text-secondary)] hover:text-[var(--color-champagne)] transition-colors duration-300 text-sm tracking-wide"
+            >
+              Back to Home
+            </Link>
+          </div>
+        </header>
+      )}
 
       <main className="mx-auto max-w-4xl px-6 py-12">
         {/* Results Header */}
@@ -285,32 +291,36 @@ export default function HexacoResults({ scores }: HexacoResultsProps) {
         </div>
 
         {/* Actions */}
-        <div className="mt-12 text-center">
-          <Link
-            to="/hexaco"
-            className="btn-ghost inline-block px-8 py-3 rounded text-xs tracking-widest uppercase mr-4"
-          >
-            Retake Assessment
-          </Link>
-          <Link
-            to="/"
-            className="btn-gold inline-block px-8 py-3 rounded text-xs tracking-widest uppercase"
-          >
-            Explore More Tests
-          </Link>
-        </div>
+        {showActions && (
+          <div className="mt-12 text-center">
+            <Link
+              to="/hexaco"
+              className="btn-ghost inline-block px-8 py-3 rounded text-xs tracking-widest uppercase mr-4"
+            >
+              Retake Assessment
+            </Link>
+            <Link
+              to="/"
+              className="btn-gold inline-block px-8 py-3 rounded text-xs tracking-widest uppercase"
+            >
+              Explore More Tests
+            </Link>
+          </div>
+        )}
       </main>
 
       {/* Footer */}
-      <footer className="border-t border-[var(--color-border)] py-12 mt-12 transition-colors duration-300">
-        <div className="mx-auto max-w-6xl px-6 text-center">
-          <p className="font-display text-xl text-gold-gradient mb-4">Mēsearch</p>
-          <p className="text-[var(--color-text-muted)] text-xs mb-2">
-            HEXACO-60 is copyrighted by K. Lee & M.C. Ashton
-          </p>
-          <p className="text-[var(--color-text-muted)]/50 text-xs">&copy; 2026</p>
-        </div>
-      </footer>
+      {showHeader && (
+        <footer className="border-t border-[var(--color-border)] py-12 mt-12 transition-colors duration-300">
+          <div className="mx-auto max-w-6xl px-6 text-center">
+            <p className="font-display text-xl text-gold-gradient mb-4">Mēsearch</p>
+            <p className="text-[var(--color-text-muted)] text-xs mb-2">
+              HEXACO-60 is copyrighted by K. Lee & M.C. Ashton
+            </p>
+            <p className="text-[var(--color-text-muted)]/50 text-xs">&copy; 2026</p>
+          </div>
+        </footer>
+      )}
     </div>
   );
 }

--- a/frontend/components/LoveLanguagesResults.tsx
+++ b/frontend/components/LoveLanguagesResults.tsx
@@ -9,30 +9,39 @@ import { styleInfo, type CommunicationStyle } from '../data/love-languages-items
 
 const RESULTS_STORAGE_KEY = 'mesearch-communication-styles-results';
 
-export default function LoveLanguagesResults() {
+interface LoveLanguagesResultsProps {
+  initialResults?: CommunicationStylesResults;
+  showHeader?: boolean;
+  showActions?: boolean;
+}
+
+export default function LoveLanguagesResults({ initialResults, showHeader = true, showActions = true }: LoveLanguagesResultsProps) {
   const navigate = useNavigate();
-  const [results, setResults] = useState<CommunicationStylesResults | null>(null);
+  const [results, setResults] = useState<CommunicationStylesResults | null>(initialResults || null);
   const [expandedStyle, setExpandedStyle] = useState<CommunicationStyle | null>(null);
 
   useEffect(() => {
-    const stored = localStorage.getItem(RESULTS_STORAGE_KEY);
-    if (stored) {
-      const parsed = deserializeResults(stored);
-      if (parsed) {
-        setResults(parsed);
+    // Only load from localStorage if no initial results provided
+    if (!initialResults) {
+      const stored = localStorage.getItem(RESULTS_STORAGE_KEY);
+      if (stored) {
+        const parsed = deserializeResults(stored);
+        if (parsed) {
+          setResults(parsed);
+        } else {
+          // Invalid data, redirect to assessment
+          navigate('/test/communication-styles');
+        }
       } else {
-        // Invalid data, redirect to assessment
+        // No results, redirect to assessment
         navigate('/test/communication-styles');
       }
-    } else {
-      // No results, redirect to assessment
-      navigate('/test/communication-styles');
     }
-  }, [navigate]);
+  }, [navigate, initialResults]);
 
   if (!results) {
     return (
-      <div className="min-h-screen bg-[var(--color-bg-primary)] flex items-center justify-center">
+      <div className={showHeader ? "min-h-screen bg-[var(--color-bg-primary)] flex items-center justify-center" : ""}>
         <div className="text-[var(--color-text-muted)]">Loading results...</div>
       </div>
     );
@@ -42,18 +51,20 @@ export default function LoveLanguagesResults() {
   const secondaryStyle = styleInfo[results.secondary];
 
   return (
-    <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
+    <div className={showHeader ? "min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300" : ""}>
       {/* Header */}
-      <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
-        <div className="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
-          <Link
-            to="/"
-            className="font-display text-2xl font-semibold tracking-wide text-gold-gradient"
-          >
-            Mesearch
-          </Link>
-        </div>
-      </header>
+      {showHeader && (
+        <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
+          <div className="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
+            <Link
+              to="/"
+              className="font-display text-2xl font-semibold tracking-wide text-gold-gradient"
+            >
+              Mesearch
+            </Link>
+          </div>
+        </header>
+      )}
 
       <main className="mx-auto max-w-3xl px-6 py-12" data-testid="love-languages-results">
         {/* Results Header */}
@@ -251,20 +262,22 @@ export default function LoveLanguagesResults() {
         </div>
 
         {/* Actions */}
-        <div className="flex flex-col sm:flex-row gap-4 justify-center">
-          <Link
-            to="/test/communication-styles"
-            className="btn-ghost px-8 py-4 rounded text-sm tracking-widest uppercase text-center"
-          >
-            Retake Assessment
-          </Link>
-          <Link
-            to="/"
-            className="btn-gold px-8 py-4 rounded text-sm tracking-widest uppercase text-center"
-          >
-            Return Home
-          </Link>
-        </div>
+        {showActions && (
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <Link
+              to="/test/communication-styles"
+              className="btn-ghost px-8 py-4 rounded text-sm tracking-widest uppercase text-center"
+            >
+              Retake Assessment
+            </Link>
+            <Link
+              to="/"
+              className="btn-gold px-8 py-4 rounded text-sm tracking-widest uppercase text-center"
+            >
+              Return Home
+            </Link>
+          </div>
+        )}
       </main>
     </div>
   );

--- a/frontend/components/MBTIResults.tsx
+++ b/frontend/components/MBTIResults.tsx
@@ -12,23 +12,32 @@ import { dimensionInfo, typeDescriptions, type Dimension } from '../data/mbti-it
 
 const RESULTS_STORAGE_KEY = 'mesearch-mbti-results';
 
-export default function MBTIResults() {
+interface MBTIResultsProps {
+  initialResults?: Results;
+  showHeader?: boolean;
+  showActions?: boolean;
+}
+
+export default function MBTIResults({ initialResults, showHeader = true, showActions = true }: MBTIResultsProps) {
   const navigate = useNavigate();
-  const [results, setResults] = useState<Results | null>(null);
+  const [results, setResults] = useState<Results | null>(initialResults || null);
   const [expandedDimension, setExpandedDimension] = useState<Dimension | null>(null);
 
   useEffect(() => {
-    const saved = localStorage.getItem(RESULTS_STORAGE_KEY);
-    if (saved) {
-      const parsed = deserializeResults(saved);
-      setResults(parsed);
+    // Only load from localStorage if no initial results provided
+    if (!initialResults) {
+      const saved = localStorage.getItem(RESULTS_STORAGE_KEY);
+      if (saved) {
+        const parsed = deserializeResults(saved);
+        setResults(parsed);
+      }
     }
-  }, []);
+  }, [initialResults]);
 
   if (!results) {
     return (
-      <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-        <Header />
+      <div className={showHeader ? "min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300" : ""}>
+        {showHeader && <Header />}
         <main className="mx-auto max-w-2xl px-6 py-16 text-center">
           <div className="card-premium rounded-lg p-10">
             <h2 className="font-display text-2xl font-medium text-[var(--color-text-primary)] mb-4">
@@ -56,10 +65,10 @@ export default function MBTIResults() {
 
   return (
     <div
-      className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300"
+      className={showHeader ? "min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300" : ""}
       data-testid="mbti-results"
     >
-      <Header />
+      {showHeader && <Header />}
       <main className="mx-auto max-w-4xl px-6 py-12">
         {/* Title */}
         <div className="text-center mb-12">
@@ -124,20 +133,22 @@ export default function MBTIResults() {
         </div>
 
         {/* Actions */}
-        <div className="flex flex-col sm:flex-row gap-4 justify-center">
-          <button
-            onClick={() => navigate('/test/mbti')}
-            className="btn-ghost px-8 py-3 rounded text-sm tracking-widest uppercase"
-          >
-            Retake Test
-          </button>
-          <Link
-            to="/"
-            className="btn-gold px-8 py-3 rounded text-sm tracking-widest uppercase text-center"
-          >
-            Explore More Tests
-          </Link>
-        </div>
+        {showActions && (
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <button
+              onClick={() => navigate('/test/mbti')}
+              className="btn-ghost px-8 py-3 rounded text-sm tracking-widest uppercase"
+            >
+              Retake Test
+            </button>
+            <Link
+              to="/"
+              className="btn-gold px-8 py-3 rounded text-sm tracking-widest uppercase text-center"
+            >
+              Explore More Tests
+            </Link>
+          </div>
+        )}
 
         {/* Attribution */}
         <div className="mt-12 text-center">

--- a/frontend/components/MFQResults.tsx
+++ b/frontend/components/MFQResults.tsx
@@ -11,23 +11,32 @@ import { foundationInfo, scoredFoundations, type Foundation, citation } from '..
 
 const RESULTS_STORAGE_KEY = 'mesearch-mfq-results';
 
-export default function MFQResults() {
+interface MFQResultsProps {
+  initialResults?: Results;
+  showHeader?: boolean;
+  showActions?: boolean;
+}
+
+export default function MFQResults({ initialResults, showHeader = true, showActions = true }: MFQResultsProps) {
   const navigate = useNavigate();
-  const [results, setResults] = useState<Results | null>(null);
+  const [results, setResults] = useState<Results | null>(initialResults || null);
   const [expandedFoundation, setExpandedFoundation] = useState<Foundation | null>(null);
 
   useEffect(() => {
-    const saved = localStorage.getItem(RESULTS_STORAGE_KEY);
-    if (saved) {
-      const parsed = deserializeResults(saved);
-      setResults(parsed);
+    // Only load from localStorage if no initial results provided
+    if (!initialResults) {
+      const saved = localStorage.getItem(RESULTS_STORAGE_KEY);
+      if (saved) {
+        const parsed = deserializeResults(saved);
+        setResults(parsed);
+      }
     }
-  }, []);
+  }, [initialResults]);
 
   if (!results) {
     return (
-      <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-        <Header />
+      <div className={showHeader ? "min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300" : ""}>
+        {showHeader && <Header />}
         <main className="mx-auto max-w-2xl px-6 py-16 text-center">
           <div className="card-premium rounded-lg p-10">
             <h2 className="font-display text-2xl font-medium text-[var(--color-text-primary)] mb-4">
@@ -51,8 +60,8 @@ export default function MFQResults() {
   const foundationScores = results.foundations;
 
   return (
-    <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-      <Header />
+    <div className={showHeader ? "min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300" : ""}>
+      {showHeader && <Header />}
       <main className="mx-auto max-w-4xl px-6 py-12">
         {/* Title */}
         <div className="text-center mb-12">
@@ -104,20 +113,22 @@ export default function MFQResults() {
         </div>
 
         {/* Actions */}
-        <div className="mt-12 flex flex-col sm:flex-row gap-4 justify-center">
-          <button
-            onClick={() => navigate('/test/mfq')}
-            className="btn-ghost px-8 py-3 rounded text-sm tracking-widest uppercase"
-          >
-            Retake Test
-          </button>
-          <Link
-            to="/"
-            className="btn-gold px-8 py-3 rounded text-sm tracking-widest uppercase text-center"
-          >
-            Explore More Tests
-          </Link>
-        </div>
+        {showActions && (
+          <div className="mt-12 flex flex-col sm:flex-row gap-4 justify-center">
+            <button
+              onClick={() => navigate('/test/mfq')}
+              className="btn-ghost px-8 py-3 rounded text-sm tracking-widest uppercase"
+            >
+              Retake Test
+            </button>
+            <Link
+              to="/"
+              className="btn-gold px-8 py-3 rounded text-sm tracking-widest uppercase text-center"
+            >
+              Explore More Tests
+            </Link>
+          </div>
+        )}
 
         {/* Citation and Disclaimer */}
         <div className="mt-12 text-center space-y-4">

--- a/frontend/components/RMETResults.tsx
+++ b/frontend/components/RMETResults.tsx
@@ -8,23 +8,32 @@ import {
 
 const RESULTS_STORAGE_KEY = 'mesearch-rmet-results';
 
-export default function RMETResults() {
+interface RMETResultsProps {
+  initialResults?: Results;
+  showHeader?: boolean;
+  showActions?: boolean;
+}
+
+export default function RMETResults({ initialResults, showHeader = true, showActions = true }: RMETResultsProps) {
   const navigate = useNavigate();
-  const [results, setResults] = useState<Results | null>(null);
+  const [results, setResults] = useState<Results | null>(initialResults || null);
   const [showItemBreakdown, setShowItemBreakdown] = useState(false);
 
   useEffect(() => {
-    const saved = localStorage.getItem(RESULTS_STORAGE_KEY);
-    if (saved) {
-      const parsed = deserializeResults(saved);
-      setResults(parsed);
+    // Only load from localStorage if no initial results provided
+    if (!initialResults) {
+      const saved = localStorage.getItem(RESULTS_STORAGE_KEY);
+      if (saved) {
+        const parsed = deserializeResults(saved);
+        setResults(parsed);
+      }
     }
-  }, []);
+  }, [initialResults]);
 
   if (!results) {
     return (
-      <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-        <Header />
+      <div className={showHeader ? "min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300" : ""}>
+        {showHeader && <Header />}
         <main className="mx-auto max-w-2xl px-6 py-16 text-center">
           <div className="card-premium rounded-lg p-10">
             <h2 className="font-display text-2xl font-medium text-[var(--color-text-primary)] mb-4">
@@ -48,8 +57,8 @@ export default function RMETResults() {
   const scoreLevel = getScoreLevel(results.totalCorrect);
 
   return (
-    <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-      <Header />
+    <div className={showHeader ? "min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300" : ""}>
+      {showHeader && <Header />}
       <main className="mx-auto max-w-4xl px-6 py-12">
         {/* Title */}
         <div className="text-center mb-12">
@@ -239,20 +248,22 @@ export default function RMETResults() {
         </div>
 
         {/* Actions */}
-        <div className="flex flex-col sm:flex-row gap-4 justify-center">
-          <button
-            onClick={() => navigate('/test/rmet')}
-            className="btn-ghost px-8 py-3 rounded text-sm tracking-widest uppercase"
-          >
-            Retake Test
-          </button>
-          <Link
-            to="/"
-            className="btn-gold px-8 py-3 rounded text-sm tracking-widest uppercase text-center"
-          >
-            Explore More Tests
-          </Link>
-        </div>
+        {showActions && (
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <button
+              onClick={() => navigate('/test/rmet')}
+              className="btn-ghost px-8 py-3 rounded text-sm tracking-widest uppercase"
+            >
+              Retake Test
+            </button>
+            <Link
+              to="/"
+              className="btn-gold px-8 py-3 rounded text-sm tracking-widest uppercase text-center"
+            >
+              Explore More Tests
+            </Link>
+          </div>
+        )}
 
         {/* Disclaimer */}
         <div className="mt-12 text-center">

--- a/frontend/components/SD3Results.tsx
+++ b/frontend/components/SD3Results.tsx
@@ -11,23 +11,32 @@ import { traitInfo, type DarkTrait } from '../data/sd3-items';
 
 const RESULTS_STORAGE_KEY = 'mesearch-sd3-results';
 
-export default function SD3Results() {
+interface SD3ResultsProps {
+  initialResults?: Results;
+  showHeader?: boolean;
+  showActions?: boolean;
+}
+
+export default function SD3Results({ initialResults, showHeader = true, showActions = true }: SD3ResultsProps) {
   const navigate = useNavigate();
-  const [results, setResults] = useState<Results | null>(null);
+  const [results, setResults] = useState<Results | null>(initialResults || null);
   const [expandedTrait, setExpandedTrait] = useState<DarkTrait | null>(null);
 
   useEffect(() => {
-    const saved = localStorage.getItem(RESULTS_STORAGE_KEY);
-    if (saved) {
-      const parsed = deserializeResults(saved);
-      setResults(parsed);
+    // Only load from localStorage if no initial results provided
+    if (!initialResults) {
+      const saved = localStorage.getItem(RESULTS_STORAGE_KEY);
+      if (saved) {
+        const parsed = deserializeResults(saved);
+        setResults(parsed);
+      }
     }
-  }, []);
+  }, [initialResults]);
 
   if (!results) {
     return (
-      <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-        <Header />
+      <div className={showHeader ? "min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300" : ""}>
+        {showHeader && <Header />}
         <main className="mx-auto max-w-2xl px-6 py-16 text-center">
           <div className="card-premium rounded-lg p-10">
             <h2 className="font-display text-2xl font-medium text-[var(--color-text-primary)] mb-4">
@@ -51,8 +60,8 @@ export default function SD3Results() {
   const traitScores = results.traits;
 
   return (
-    <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-      <Header />
+    <div className={showHeader ? "min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300" : ""}>
+      {showHeader && <Header />}
       <main className="mx-auto max-w-4xl px-6 py-12">
         {/* Title */}
         <div className="text-center mb-12">
@@ -133,20 +142,22 @@ export default function SD3Results() {
         </div>
 
         {/* Actions */}
-        <div className="mt-12 flex flex-col sm:flex-row gap-4 justify-center">
-          <button
-            onClick={() => navigate('/test/sd3')}
-            className="btn-ghost px-8 py-3 rounded text-sm tracking-widest uppercase"
-          >
-            Retake Test
-          </button>
-          <Link
-            to="/"
-            className="btn-gold px-8 py-3 rounded text-sm tracking-widest uppercase text-center"
-          >
-            Explore More Tests
-          </Link>
-        </div>
+        {showActions && (
+          <div className="mt-12 flex flex-col sm:flex-row gap-4 justify-center">
+            <button
+              onClick={() => navigate('/test/sd3')}
+              className="btn-ghost px-8 py-3 rounded text-sm tracking-widest uppercase"
+            >
+              Retake Test
+            </button>
+            <Link
+              to="/"
+              className="btn-gold px-8 py-3 rounded text-sm tracking-widest uppercase text-center"
+            >
+              Explore More Tests
+            </Link>
+          </div>
+        )}
 
         {/* Citation */}
         <div className="mt-12 text-center">

--- a/frontend/pages/ResultDetail.tsx
+++ b/frontend/pages/ResultDetail.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect } from 'react';
 import { Link, useParams, useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { UserMenu } from '../components/UserMenu';
+import BigFiveResults from '../components/BigFiveResults';
+import type { BigFiveResults as BigFiveResultsType } from '../data/big-five-scoring';
 
 interface TestResult {
   id: string;
@@ -170,11 +172,29 @@ export function ResultDetail() {
         </div>
 
         {/* Results display based on test type */}
-        <div className="card-premium rounded-lg p-8" data-testid="result-detail-content">
-          {result.test_type === 'mini_test' && <MiniTestResultDisplay scores={result.scores} />}
-          {result.test_type === 'big-five' && <BigFiveResultDisplay scores={result.scores} />}
-          {result.test_type === 'enneagram' && <EnneagramResultDisplay scores={result.scores} />}
-          {result.test_type === 'hexaco' && <HexacoResultDisplay scores={result.scores} />}
+        <div data-testid="result-detail-content">
+          {result.test_type === 'mini_test' && (
+            <div className="card-premium rounded-lg p-8">
+              <MiniTestResultDisplay scores={result.scores} />
+            </div>
+          )}
+          {result.test_type === 'big-five' && (
+            <BigFiveResults
+              initialResults={result.scores as unknown as BigFiveResultsType}
+              showHeader={false}
+              showActions={false}
+            />
+          )}
+          {result.test_type === 'enneagram' && (
+            <div className="card-premium rounded-lg p-8">
+              <EnneagramResultDisplay scores={result.scores} />
+            </div>
+          )}
+          {result.test_type === 'hexaco' && (
+            <div className="card-premium rounded-lg p-8">
+              <HexacoResultDisplay scores={result.scores} />
+            </div>
+          )}
         </div>
 
         {/* Actions */}

--- a/frontend/pages/ResultDetail.tsx
+++ b/frontend/pages/ResultDetail.tsx
@@ -3,7 +3,25 @@ import { Link, useParams, useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { UserMenu } from '../components/UserMenu';
 import BigFiveResults from '../components/BigFiveResults';
+import { EnneagramResults } from '../components/EnneagramResults';
+import HexacoResults from '../components/HexacoResults';
+import ECRResults from '../components/ECRResults';
+import MBTIResults from '../components/MBTIResults';
+import MFQResults from '../components/MFQResults';
+import SD3Results from '../components/SD3Results';
+import LoveLanguagesResults from '../components/LoveLanguagesResults';
+import RMETResults from '../components/RMETResults';
+import CRTResultsComponent from '../components/CRTResults';
 import type { BigFiveResults as BigFiveResultsType } from '../data/big-five-scoring';
+import type { EnneagramResult } from '../data/enneagram-scoring';
+import type { DimensionScore as HexacoDimensionScore } from '../data/hexaco-scoring';
+import type { ECRResults as ECRResultsType } from '../data/ecr-scoring';
+import type { MBTIResults as MBTIResultsType } from '../data/mbti-scoring';
+import type { MFQResults as MFQResultsType } from '../data/mfq-scoring';
+import type { SD3Results as SD3ResultsType } from '../data/sd3-scoring';
+import type { CommunicationStylesResults } from '../data/love-languages-scoring';
+import type { RMETResults as RMETResultsType } from '../data/rmet-scoring';
+import type { CRTResults } from '../data/crt-scoring';
 
 interface TestResult {
   id: string;
@@ -61,6 +79,13 @@ export function ResultDetail() {
       'big-five': 'Big Five',
       hexaco: 'HEXACO',
       mini_test: 'Mini-Test',
+      ecr: 'Attachment Style',
+      mbti: 'Myers-Briggs Type',
+      mfq: 'Moral Foundations',
+      sd3: 'Short Dark Triad',
+      'communication-styles': 'Communication Styles',
+      rmet: 'Reading the Mind in the Eyes',
+      crt: 'Cognitive Reflection Test',
     };
     return names[testType] || testType;
   }
@@ -71,6 +96,13 @@ export function ResultDetail() {
       'big-five': '/test/big-five',
       hexaco: '/hexaco',
       mini_test: '/test/mini-test',
+      ecr: '/test/ecr',
+      mbti: '/test/mbti',
+      mfq: '/test/mfq',
+      sd3: '/test/sd3',
+      'communication-styles': '/test/communication-styles',
+      rmet: '/test/rmet',
+      crt: '/test/crt',
     };
     return urls[testType] || '/';
   }
@@ -186,14 +218,66 @@ export function ResultDetail() {
             />
           )}
           {result.test_type === 'enneagram' && (
-            <div className="card-premium rounded-lg p-8">
-              <EnneagramResultDisplay scores={result.scores} />
-            </div>
+            <EnneagramResults
+              result={result.scores as unknown as EnneagramResult}
+              onRetake={() => navigate(getRetakeUrl('enneagram'))}
+              showActions={false}
+            />
           )}
           {result.test_type === 'hexaco' && (
-            <div className="card-premium rounded-lg p-8">
-              <HexacoResultDisplay scores={result.scores} />
-            </div>
+            <HexacoResults
+              scores={result.scores as unknown as HexacoDimensionScore[]}
+              showHeader={false}
+              showActions={false}
+            />
+          )}
+          {result.test_type === 'ecr' && (
+            <ECRResults
+              initialResults={result.scores as unknown as ECRResultsType}
+              showHeader={false}
+              showActions={false}
+            />
+          )}
+          {result.test_type === 'mbti' && (
+            <MBTIResults
+              initialResults={result.scores as unknown as MBTIResultsType}
+              showHeader={false}
+              showActions={false}
+            />
+          )}
+          {result.test_type === 'mfq' && (
+            <MFQResults
+              initialResults={result.scores as unknown as MFQResultsType}
+              showHeader={false}
+              showActions={false}
+            />
+          )}
+          {result.test_type === 'sd3' && (
+            <SD3Results
+              initialResults={result.scores as unknown as SD3ResultsType}
+              showHeader={false}
+              showActions={false}
+            />
+          )}
+          {result.test_type === 'communication-styles' && (
+            <LoveLanguagesResults
+              initialResults={result.scores as unknown as CommunicationStylesResults}
+              showHeader={false}
+              showActions={false}
+            />
+          )}
+          {result.test_type === 'rmet' && (
+            <RMETResults
+              initialResults={result.scores as unknown as RMETResultsType}
+              showHeader={false}
+              showActions={false}
+            />
+          )}
+          {result.test_type === 'crt' && (
+            <CRTResultsComponent
+              results={result.scores as unknown as CRTResults}
+              onRetake={() => navigate(getRetakeUrl('crt'))}
+            />
           )}
         </div>
 
@@ -238,7 +322,7 @@ function Header() {
   );
 }
 
-// Mini-Test result display
+// Mini-Test result display (kept as simple display since it's a debug test)
 interface MiniTestScores {
   dimensionScores?: { dimension: string; dimensionName: string; score: number; color: string }[];
 }
@@ -268,199 +352,6 @@ function MiniTestResultDisplay({ scores }: { scores: Record<string, unknown> }) 
           <span className="text-[var(--color-text-secondary)]">
             {score.score} / 5
           </span>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-// Big Five result display
-interface BigFiveScores {
-  dimensions?: { dimension: string; meanScore: number; percentile: number }[];
-}
-
-function BigFiveResultDisplay({ scores }: { scores: Record<string, unknown> }) {
-  const typedScores = scores as BigFiveScores;
-  const dimensions = typedScores.dimensions || [];
-
-  const dimensionNames: Record<string, string> = {
-    O: 'Openness',
-    C: 'Conscientiousness',
-    E: 'Extraversion',
-    A: 'Agreeableness',
-    N: 'Neuroticism',
-  };
-
-  const dimensionColors: Record<string, string> = {
-    O: '#9b87f5',
-    C: '#22d3ee',
-    E: '#fbbf24',
-    A: '#34d399',
-    N: '#f472b6',
-  };
-
-  if (dimensions.length === 0) {
-    return <p className="text-[var(--color-text-muted)]">No detailed scores available.</p>;
-  }
-
-  return (
-    <div className="space-y-6">
-      <h3 className="font-display text-lg text-[var(--color-text-primary)] mb-4">Dimension Scores</h3>
-      {dimensions.map((dim) => (
-        <div key={dim.dimension}>
-          <div className="flex items-center justify-between mb-2">
-            <div className="flex items-center gap-3">
-              <div
-                className="w-3 h-3 rounded-full"
-                style={{ backgroundColor: dimensionColors[dim.dimension] || 'var(--color-champagne)' }}
-              />
-              <span className="text-[var(--color-text-primary)] font-medium">
-                {dimensionNames[dim.dimension] || dim.dimension}
-              </span>
-            </div>
-            <span className="text-[var(--color-text-secondary)] text-sm">
-              {dim.percentile}th percentile
-            </span>
-          </div>
-          <div className="h-2 bg-[var(--color-bg-tertiary)] rounded-full overflow-hidden">
-            <div
-              className="h-full rounded-full transition-all duration-500"
-              style={{
-                width: `${dim.percentile}%`,
-                backgroundColor: dimensionColors[dim.dimension] || 'var(--color-champagne)',
-              }}
-            />
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-// Enneagram result display
-interface EnneagramScores {
-  primaryType?: number;
-  wing?: number;
-  wingLabel?: string;
-  scores?: { type: number; percentage: number }[];
-}
-
-function EnneagramResultDisplay({ scores }: { scores: Record<string, unknown> }) {
-  const typedScores = scores as EnneagramScores;
-  const typeScores = typedScores.scores || [];
-
-  const typeNames: Record<number, string> = {
-    1: 'The Reformer',
-    2: 'The Helper',
-    3: 'The Achiever',
-    4: 'The Individualist',
-    5: 'The Investigator',
-    6: 'The Loyalist',
-    7: 'The Enthusiast',
-    8: 'The Challenger',
-    9: 'The Peacemaker',
-  };
-
-  return (
-    <div className="space-y-6">
-      {typedScores.primaryType && (
-        <div className="text-center mb-8">
-          <p className="text-[var(--color-champagne)] text-xs tracking-[0.3em] uppercase mb-2">Primary Type</p>
-          <h3 className="font-display text-4xl font-medium text-[var(--color-text-primary)]">
-            Type {typedScores.primaryType}
-          </h3>
-          <p className="text-gold-gradient text-xl">{typeNames[typedScores.primaryType]}</p>
-          {typedScores.wingLabel && (
-            <p className="text-[var(--color-text-muted)] text-sm mt-2">{typedScores.wingLabel}</p>
-          )}
-        </div>
-      )}
-
-      {typeScores.length > 0 && (
-        <div>
-          <h4 className="font-display text-lg text-[var(--color-text-primary)] mb-4">All Type Scores</h4>
-          <div className="space-y-3">
-            {typeScores
-              .sort((a, b) => b.percentage - a.percentage)
-              .map((score) => (
-                <div key={score.type}>
-                  <div className="flex items-center justify-between mb-1">
-                    <span className="text-[var(--color-text-primary)]">
-                      Type {score.type} - {typeNames[score.type]}
-                    </span>
-                    <span className="text-[var(--color-text-secondary)] text-sm">
-                      {score.percentage}%
-                    </span>
-                  </div>
-                  <div className="h-2 bg-[var(--color-bg-tertiary)] rounded-full overflow-hidden">
-                    <div
-                      className="h-full rounded-full transition-all duration-500"
-                      style={{
-                        width: `${score.percentage}%`,
-                        backgroundColor: score.type === typedScores.primaryType ? 'var(--color-champagne)' : 'var(--color-text-muted)',
-                        opacity: score.type === typedScores.primaryType ? 1 : 0.4,
-                      }}
-                    />
-                  </div>
-                </div>
-              ))}
-          </div>
-        </div>
-      )}
-
-      {typeScores.length === 0 && !typedScores.primaryType && (
-        <p className="text-[var(--color-text-muted)]">No detailed scores available.</p>
-      )}
-    </div>
-  );
-}
-
-// HEXACO result display
-interface HexacoScores {
-  dimension?: string;
-  score?: number;
-  facetScores?: { facet: string; score: number }[];
-}
-
-function HexacoResultDisplay({ scores }: { scores: Record<string, unknown> }) {
-  // HEXACO scores come as an array of dimension scores
-  const dimensionScores = Array.isArray(scores) ? scores as HexacoScores[] : [];
-
-  const dimensionColors: Record<string, string> = {
-    'Honesty-Humility': 'var(--color-champagne)',
-    'Emotionality': '#a888a8',
-    'Extraversion': '#e8a87c',
-    'Agreeableness': '#7cb8a8',
-    'Conscientiousness': '#8899cc',
-    'Openness': '#cc8899',
-  };
-
-  if (dimensionScores.length === 0) {
-    return <p className="text-[var(--color-text-muted)]">No detailed scores available.</p>;
-  }
-
-  return (
-    <div className="space-y-6">
-      <h3 className="font-display text-lg text-[var(--color-text-primary)] mb-4">Dimension Scores</h3>
-      {dimensionScores.map((dim) => (
-        <div key={dim.dimension}>
-          <div className="flex items-center justify-between mb-2">
-            <span className="text-[var(--color-text-primary)] font-medium">
-              {dim.dimension}
-            </span>
-            <span className="text-[var(--color-text-secondary)] text-sm">
-              {dim.score?.toFixed(2)} / 5
-            </span>
-          </div>
-          <div className="h-2 bg-[var(--color-bg-tertiary)] rounded-full overflow-hidden">
-            <div
-              className="h-full rounded-full transition-all duration-500"
-              style={{
-                width: `${((dim.score || 0) / 5) * 100}%`,
-                backgroundColor: dimensionColors[dim.dimension || ''] || 'var(--color-champagne)',
-              }}
-            />
-          </div>
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary

- Modified all Results components to accept optional `initialResults` prop so they can be reused from the ResultDetail page
- When viewing results from history, users now see the complete visualization - matching what they saw when first completing each test
- Added `showHeader` and `showActions` props to control display when embedded in other pages

### Components updated:
- BigFiveResults (radar chart, expandable dimension cards, facet breakdowns)
- EnneagramResults (type breakdown, wing info, detailed descriptions)
- HexacoResults (dimension bars with scores)
- ECRResults (attachment style quadrant, anxiety/avoidance scores)
- MBTIResults (type breakdown, dimension preferences)
- MFQResults (radar chart, foundation cards with percentiles)
- SD3Results (triangle chart, trait cards with percentiles)
- LoveLanguagesResults (style ranking, primary/secondary breakdown)
- RMETResults (score circle, distribution chart, item breakdown)
- CRTResults (already supported via required results prop)

## Test plan

- [x] All 308 unit tests pass
- [ ] CI unit tests pass
- [ ] CI E2E tests pass
- [ ] Verify results from history show full visualizations (manual check)

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)