### PR TITLE
Add consistent navigation across all pages

### DIFF
--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -5,7 +5,7 @@ test.describe('Authentication - Unauthenticated', () => {
     await page.goto('/');
 
     // Check that the page loads
-    await expect(page.getByRole('link', { name: 'Mesearch' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Mesearch', exact: true })).toBeVisible();
 
     // Check for Sign In link (when not logged in)
     await expect(page.getByRole('link', { name: 'Sign In' })).toBeVisible();

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -63,7 +63,7 @@ test.describe('Authentication - Dev Login Flow', () => {
     await expect(page.getByRole('button').filter({ hasText: 'J' })).toBeVisible();
   });
 
-  test('user menu shows My Results link', async ({ page }) => {
+  test('user menu shows Settings link', async ({ page }) => {
     // Login first
     await page.goto('/api/auth/dev-login?email=test@example.com');
     await expect(page).toHaveURL('/');
@@ -71,8 +71,17 @@ test.describe('Authentication - Dev Login Flow', () => {
     // Click user menu to open dropdown
     await page.getByRole('button').filter({ hasText: 'T' }).click();
 
-    // Should see My Results link in dropdown
-    await expect(page.getByRole('link', { name: 'My Results' })).toBeVisible();
+    // Should see Settings link in dropdown (My Results moved to main nav as "Results")
+    await expect(page.getByRole('link', { name: 'Settings' })).toBeVisible();
+  });
+
+  test('Results link is visible in main nav when logged in', async ({ page }) => {
+    // Login first
+    await page.goto('/api/auth/dev-login?email=test@example.com');
+    await expect(page).toHaveURL('/');
+
+    // Should see Results link in the main nav
+    await expect(page.getByRole('link', { name: 'Results' })).toBeVisible();
   });
 
   test('logout clears session', async ({ page }) => {

--- a/e2e/crt.spec.ts
+++ b/e2e/crt.spec.ts
@@ -8,16 +8,16 @@ test.describe('Cognitive Reflection Test (CRT)', () => {
   });
 
   test.describe('Navigation and Intro', () => {
-    test('CRT card is visible on homepage', async ({ page }) => {
-      await page.goto('/');
+    test('CRT card is visible on tests page', async ({ page }) => {
+      await page.goto('/tests');
 
       // Should see the CRT test card
       await expect(page.getByRole('heading', { name: 'CRT' })).toBeVisible();
       await expect(page.getByText('Cognitive Reflection')).toBeVisible();
     });
 
-    test('can navigate to CRT from homepage', async ({ page }) => {
-      await page.goto('/');
+    test('can navigate to CRT from tests page', async ({ page }) => {
+      await page.goto('/tests');
 
       // Find the CRT card and click the begin button
       const crtCard = page.locator('.card-premium', { has: page.getByRole('heading', { name: 'CRT' }) });

--- a/e2e/ecr.spec.ts
+++ b/e2e/ecr.spec.ts
@@ -140,8 +140,8 @@ test.describe('ECR Attachment Style Assessment', () => {
     await expect(page.getByTestId('ecr-progress')).toContainText('1 of 9');
   });
 
-  test('ECR card is visible on homepage', async ({ page }) => {
-    await page.goto('/');
+  test('ECR card is visible on tests page', async ({ page }) => {
+    await page.goto('/tests');
 
     // Verify ECR test card is present
     await expect(page.getByText('Attachment Style')).toBeVisible();

--- a/e2e/hexaco.spec.ts
+++ b/e2e/hexaco.spec.ts
@@ -11,8 +11,8 @@ test.describe('HEXACO-60 Assessment', () => {
     // Navigate to HEXACO assessment
     await page.goto('/hexaco');
 
-    // Verify we're on the assessment page
-    await expect(page.getByText('HEXACO-60 Assessment')).toBeVisible();
+    // Verify we're on the assessment page (HEXACO goes directly to questions, no intro)
+    await expect(page.getByText('Question 1')).toBeVisible();
 
     // Answer all 60 questions with "Neutral" (value 3)
     for (let i = 1; i <= 60; i++) {

--- a/e2e/love-languages.spec.ts
+++ b/e2e/love-languages.spec.ts
@@ -1,9 +1,9 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Communication Styles Assessment', () => {
-  test.describe('Homepage', () => {
-    test('communication styles card is visible on homepage', async ({ page }) => {
-      await page.goto('/');
+  test.describe('Tests Page', () => {
+    test('communication styles card is visible on tests page', async ({ page }) => {
+      await page.goto('/tests');
 
       // Should see the Communication Styles test card
       await expect(page.getByRole('heading', { name: 'Communication Styles' })).toBeVisible();

--- a/e2e/mbti.spec.ts
+++ b/e2e/mbti.spec.ts
@@ -7,8 +7,8 @@ test.describe('Myers-Briggs Style Test (OEJTS)', () => {
     await page.evaluate(() => localStorage.clear());
   });
 
-  test('MBTI test card is visible on homepage', async ({ page }) => {
-    await page.goto('/');
+  test('MBTI test card is visible on tests page', async ({ page }) => {
+    await page.goto('/tests');
 
     // MBTI card should be visible
     await expect(page.getByRole('heading', { name: 'Myers-Briggs' })).toBeVisible();
@@ -16,7 +16,7 @@ test.describe('Myers-Briggs Style Test (OEJTS)', () => {
   });
 
   test('can navigate to MBTI assessment and see intro', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/tests');
 
     // Click on the MBTI test card's "Begin Assessment" link
     const mbtiCard = page.locator('.card-premium', { hasText: 'Myers-Briggs' });

--- a/e2e/mfq.spec.ts
+++ b/e2e/mfq.spec.ts
@@ -96,8 +96,8 @@ test.describe('Moral Foundations Questionnaire Assessment', () => {
     await expect(page.getByText('6 of 30')).toBeVisible();
   });
 
-  test('shows MFQ card on homepage', async ({ page }) => {
-    await page.goto('/');
+  test('shows MFQ card on tests page', async ({ page }) => {
+    await page.goto('/tests');
 
     // Verify the MFQ test card is visible
     await expect(page.getByText('Moral Foundations')).toBeVisible();

--- a/e2e/mini-test.spec.ts
+++ b/e2e/mini-test.spec.ts
@@ -2,10 +2,13 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Mini-Test Feature Flag', () => {
   test.describe('Regular Users (No Access)', () => {
-    test('mini-test section is NOT visible on homepage for regular users', async ({ page }) => {
+    test('mini-test section is NOT visible on tests page for regular users', async ({ page }) => {
       // Login as a regular user (not admin, no +test in email)
       await page.goto('/api/auth/dev-login?email=regular@example.com');
       await expect(page).toHaveURL('/');
+
+      // Go to tests page where mini-test section would be displayed
+      await page.goto('/tests');
 
       // Mini-test section should NOT be visible
       await expect(page.getByTestId('mini-test-section')).not.toBeVisible();
@@ -24,7 +27,7 @@ test.describe('Mini-Test Feature Flag', () => {
     });
 
     test('unauthenticated users cannot see mini-test', async ({ page }) => {
-      await page.goto('/');
+      await page.goto('/tests');
 
       // Mini-test section should NOT be visible
       await expect(page.getByTestId('mini-test-section')).not.toBeVisible();
@@ -36,6 +39,9 @@ test.describe('Mini-Test Feature Flag', () => {
       // Login with +test in email (URL encode the + as %2B)
       await page.goto('/api/auth/dev-login?email=user%2Btest@example.com');
       await expect(page).toHaveURL('/');
+
+      // Go to tests page where mini-test section is displayed
+      await page.goto('/tests');
 
       // Mini-test section should be visible
       await expect(page.getByTestId('mini-test-section')).toBeVisible();
@@ -81,6 +87,9 @@ test.describe('Mini-Test Feature Flag', () => {
       // Login as admin
       await page.goto('/api/auth/dev-login?email=emily.cogsdill@gmail.com');
       await expect(page).toHaveURL('/');
+
+      // Go to tests page where mini-test section is displayed
+      await page.goto('/tests');
 
       // Mini-test section should be visible
       await expect(page.getByTestId('mini-test-section')).toBeVisible();

--- a/e2e/rmet.spec.ts
+++ b/e2e/rmet.spec.ts
@@ -159,8 +159,8 @@ test.describe('RMET Assessment', () => {
     await expect(page.getByText('2 of 37')).toBeVisible();
   });
 
-  test('displays RMET card on home page', async ({ page }) => {
-    await page.goto('/');
+  test('displays RMET card on tests page', async ({ page }) => {
+    await page.goto('/tests');
 
     // Should see RMET test card
     await expect(page.getByRole('heading', { name: 'RMET' })).toBeVisible();

--- a/e2e/sd3.spec.ts
+++ b/e2e/sd3.spec.ts
@@ -88,8 +88,8 @@ test.describe('Short Dark Triad (SD3) Assessment', () => {
     await expect(page.getByTestId('sd3-progress')).toHaveText('6 of 27');
   });
 
-  test('SD3 test card is visible on home page', async ({ page }) => {
-    await page.goto('/');
+  test('SD3 test card is visible on tests page', async ({ page }) => {
+    await page.goto('/tests');
 
     // Verify the SD3 test card is displayed - scope to the card to avoid strict mode violations
     const sd3Card = page.locator('.card-premium', { has: page.getByRole('heading', { name: 'Dark Triad' }) });
@@ -99,8 +99,8 @@ test.describe('Short Dark Triad (SD3) Assessment', () => {
     await expect(sd3Card.getByText('Machiavellianism, Narcissism, and Psychopathy')).toBeVisible();
   });
 
-  test('can navigate to SD3 from home page', async ({ page }) => {
-    await page.goto('/');
+  test('can navigate to SD3 from tests page', async ({ page }) => {
+    await page.goto('/tests');
 
     // Find the SD3 test card and click "Begin Assessment"
     // The card contains "Dark Triad" heading and has a Begin Assessment link

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -30,10 +30,9 @@ import MBTIAssessment from './components/MBTIAssessment';
 import MBTIResults from './components/MBTIResults';
 import RMETAssessment from './components/RMETAssessment';
 import RMETResults from './components/RMETResults';
+import { TestsPage } from './pages/TestsPage';
 
 function HomePage() {
-  const { flags } = useFeatureFlags();
-
   return (
     <Layout>
       <main>
@@ -58,157 +57,12 @@ function HomePage() {
               <li>Question the nature of your reality.</li>
             </ul>
           </div>
-          <a
-            href="#tests"
+          <Link
+            to="/tests"
             className="btn-gold inline-block px-10 py-4 rounded text-sm tracking-widest uppercase"
           >
             Explore Tests
-          </a>
-        </section>
-
-        {/* Divider */}
-        <div className="divider-elegant mx-auto max-w-md" />
-
-        {/* Tests Section */}
-        <section id="tests" className="mx-auto max-w-6xl px-6 py-24 scroll-mt-24">
-          <div className="text-center mb-16">
-            <p className="text-[var(--color-champagne)] text-xs tracking-[0.3em] uppercase mb-4">Assessments</p>
-            <h3 className="font-display text-4xl font-medium text-[var(--color-text-primary)] transition-colors duration-300">Featured Tests</h3>
-          </div>
-          <div className="grid md:grid-cols-3 gap-8">
-            <TestCard
-              title="Big Five"
-              subtitle="IPIP-NEO"
-              slug="big-five"
-              keywords={['Traits', 'Behavior', 'Stability']}
-              description="The gold standard in personality psychology. Measures Openness, Conscientiousness, Extraversion, Agreeableness, and Neuroticism."
-              time="15 min"
-              seriousness={5}
-              fun={3}
-            />
-            <TestCard
-              title="HEXACO"
-              subtitle="Six Dimensions"
-              slug="hexaco"
-              link="/hexaco"
-              keywords={['Ethics', 'Honesty', 'Integrity']}
-              description="Six-factor model including Honesty-Humility. Predicts ethical behavior and workplace conduct with precision."
-              time="12 min"
-              seriousness={5}
-              fun={2}
-            />
-            <TestCard
-              title="Enneagram"
-              subtitle="Nine Types"
-              slug="enneagram"
-              keywords={['Motivations', 'Growth', 'Archetypes']}
-              description="Explore your core motivations through nine distinct personality archetypes. Renowned for personal growth insights."
-              time="10 min"
-              seriousness={2}
-              fun={5}
-            />
-            <TestCard
-              title="Communication Styles"
-              subtitle="Five Styles"
-              slug="communication-styles"
-              keywords={['Relationships', 'Appreciation', 'Connection']}
-              description="Discover how you prefer to give and receive appreciation. Learn your primary style for deeper connections."
-              time="5 min"
-              seriousness={2}
-              fun={5}
-            />
-            <TestCard
-              title="Attachment Style"
-              subtitle="ECR-RS"
-              slug="ecr"
-              keywords={['Relationships', 'Anxiety', 'Avoidance']}
-              description="Understand your attachment patterns in close relationships. Measures anxiety and avoidance on continuous dimensions."
-              time="5 min"
-              seriousness={5}
-              fun={4}
-            />
-            <TestCard
-              title="CRT"
-              subtitle="Cognitive Reflection"
-              slug="crt"
-              keywords={['Reasoning', 'Reflection', 'Intuition']}
-              description="Test your ability to override intuitive wrong answers through deliberate reflection. The famous 'bat and ball' problem and more."
-              time="5 min"
-              seriousness={4}
-              fun={5}
-            />
-          </div>
-
-          {/* Second Row - Popular but less scientific */}
-          <div className="grid md:grid-cols-3 gap-8 mt-8">
-            <TestCard
-              title="Myers-Briggs"
-              subtitle="OEJTS"
-              slug="mbti"
-              keywords={['Types', 'Cognitive', 'Popular']}
-              description="The world's most popular personality test. Discover your type across four dichotomies: E/I, S/N, T/F, J/P."
-              time="10 min"
-              seriousness={2}
-              fun={5}
-            />
-            <TestCard
-              title="Moral Foundations"
-              subtitle="MFQ-30"
-              slug="mfq"
-              keywords={['Ethics', 'Values', 'Politics']}
-              description="Discover your moral intuitions across five foundations: Care, Fairness, Loyalty, Authority, and Purity. Based on Jonathan Haidt's research."
-              time="10 min"
-              seriousness={4}
-              fun={4}
-            />
-            <TestCard
-              title="Dark Triad"
-              subtitle="SD3"
-              slug="sd3"
-              keywords={['Strategy', 'Confidence', 'Boldness']}
-              description="Measures subclinical Machiavellianism, Narcissism, and Psychopathy. High engagement due to 'forbidden' appeal."
-              time="5 min"
-              seriousness={4}
-              fun={5}
-            />
-          </div>
-
-          {/* Additional Tests Row */}
-          <div className="grid md:grid-cols-3 gap-8 mt-8">
-            <TestCard
-              title="RMET"
-              subtitle="Eyes Test"
-              slug="rmet"
-              keywords={['Social Cognition', 'Empathy', 'Theory of Mind']}
-              description="Measure your ability to recognize emotions and mental states from eye expressions. Research-backed assessment of social cognition."
-              time="10 min"
-              seriousness={4}
-              fun={4}
-            />
-          </div>
-
-          {/* Mini-Test - Admin/Test Users Only */}
-          {flags.mini_test && (
-            <div className="mt-8" data-testid="mini-test-section">
-              <div className="text-center mb-6">
-                <span className="inline-block px-3 py-1 rounded-full bg-amber-500/20 border border-amber-500/30 text-amber-400 text-xs tracking-wide uppercase">
-                  Debug / Testing Only
-                </span>
-              </div>
-              <div className="max-w-md mx-auto">
-                <TestCard
-                  title="Mini-Test"
-                  subtitle="5 Questions"
-                  slug="mini-test"
-                  keywords={['Debug', 'Testing', 'Quick']}
-                  description="A 5-question sampler for debugging and automated testing. One question from each Big Five dimension."
-                  time="1 min"
-                  seriousness={1}
-                  fun={1}
-                />
-              </div>
-            </div>
-          )}
+          </Link>
         </section>
 
         {/* Divider */}
@@ -271,59 +125,6 @@ function RatingDots({ value, max = 5 }: { value: number; max?: number }) {
           }`}
         />
       ))}
-    </div>
-  );
-}
-
-function TestCard({
-  title,
-  subtitle,
-  slug,
-  keywords,
-  description,
-  time,
-  seriousness,
-  fun,
-  link,
-}: {
-  title: string;
-  subtitle: string;
-  slug: string;
-  keywords: string[];
-  description: string;
-  time: string;
-  seriousness: number;
-  fun: number;
-  link?: string;
-}) {
-  const href = link || `/test/${slug}`;
-  return (
-    <div className="card-premium rounded-lg p-8 group">
-      <div className="flex items-center justify-between mb-6">
-        <div className="flex gap-6">
-          <div className="flex items-center gap-2">
-            <span className="text-[var(--color-text-muted)] text-[10px] tracking-wide uppercase">Seriousness</span>
-            <RatingDots value={seriousness} />
-          </div>
-          <div className="flex items-center gap-2">
-            <span className="text-[var(--color-text-muted)] text-[10px] tracking-wide uppercase">Fun</span>
-            <RatingDots value={fun} />
-          </div>
-        </div>
-        <span className="text-[var(--color-text-muted)] text-xs tracking-wide">{time}</span>
-      </div>
-      <h4 className="font-display text-2xl font-medium text-[var(--color-text-primary)] mb-1 transition-colors duration-300">{title}</h4>
-      <p className="text-[var(--color-champagne)]/70 text-sm mb-4 tracking-wide">{subtitle}</p>
-      <p className="text-[var(--color-text-muted)] text-xs mb-3 tracking-wide">
-        {keywords.join(' · ')}
-      </p>
-      <p className="text-[var(--color-text-secondary)] text-sm mb-8 leading-relaxed transition-colors duration-300">{description}</p>
-      <Link
-        to={href}
-        className="btn-ghost block w-full py-3 rounded text-center text-xs tracking-widest uppercase"
-      >
-        Begin Assessment
-      </Link>
     </div>
   );
 }
@@ -632,6 +433,7 @@ export default function App() {
         <FeatureFlagsProvider>
           <Routes>
             <Route path="/" element={<HomePage />} />
+            <Route path="/tests" element={<TestsPage />} />
             <Route path="/my-results" element={<ResultsHistory />} />
             <Route path="/results/:id" element={<ResultDetail />} />
             <Route path="/settings" element={<Settings />} />

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -70,6 +70,12 @@ function HomePage() {
       <footer className="border-t border-[var(--color-border)] py-12 transition-colors duration-300">
         <div className="mx-auto max-w-6xl px-6 text-center">
           <p className="font-display text-xl text-gold-gradient mb-4">Mesearch</p>
+          <a
+            href="mailto:hello@mesearcher.com"
+            className="text-[var(--color-text-muted)] hover:text-[var(--color-champagne)] transition-colors duration-300 text-sm mb-4 inline-block"
+          >
+            hello@mesearcher.com
+          </a>
           <p className="text-[var(--color-text-muted)]/50 text-xs">&copy; 2026</p>
         </div>
       </footer>

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,5 +1,5 @@
 import { Routes, Route, Link, useParams } from 'react-router-dom';
-import { createContext, useContext, useEffect, useState } from 'react';
+import { useState } from 'react';
 import HexacoAssessment from './components/HexacoAssessment';
 import HexacoResults from './components/HexacoResults';
 import { HexacoResponse, calculateScores, DimensionScore } from './data/hexaco-scoring';
@@ -14,7 +14,7 @@ import { calculateEnneagramResult, type EnneagramResult } from './data/enneagram
 import { EnneagramResults } from './components/EnneagramResults';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { FeatureFlagsProvider, useFeatureFlags } from './contexts/FeatureFlagsContext';
-import { UserMenu } from './components/UserMenu';
+import { Layout, ThemeProvider } from './components/Layout';
 import { ResultsHistory } from './pages/ResultsHistory';
 import { ResultDetail } from './pages/ResultDetail';
 import { Settings } from './pages/Settings';
@@ -31,140 +31,11 @@ import MBTIResults from './components/MBTIResults';
 import RMETAssessment from './components/RMETAssessment';
 import RMETResults from './components/RMETResults';
 
-// Theme Context
-type Theme = 'dark' | 'light';
-
-const ThemeContext = createContext<{
-  theme: Theme;
-  toggleTheme: () => void;
-}>({
-  theme: 'dark',
-  toggleTheme: () => {},
-});
-
-function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [theme, setTheme] = useState<Theme>(() => {
-    if (typeof window !== 'undefined') {
-      const saved = localStorage.getItem('mesearch-theme');
-      return (saved as Theme) || 'dark';
-    }
-    return 'dark';
-  });
-
-  useEffect(() => {
-    const root = document.documentElement;
-    if (theme === 'light') {
-      root.classList.add('light');
-    } else {
-      root.classList.remove('light');
-    }
-    localStorage.setItem('mesearch-theme', theme);
-  }, [theme]);
-
-  const toggleTheme = () => {
-    setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'));
-  };
-
-  return (
-    <ThemeContext.Provider value={{ theme, toggleTheme }}>
-      {children}
-    </ThemeContext.Provider>
-  );
-}
-
-function useTheme() {
-  return useContext(ThemeContext);
-}
-
-// Theme Toggle Button
-function ThemeToggle() {
-  const { theme, toggleTheme } = useTheme();
-
-  return (
-    <button
-      onClick={toggleTheme}
-      className="theme-toggle"
-      aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
-    >
-      {theme === 'dark' ? (
-        // Sun icon for switching to light
-        <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={1.5}
-            d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"
-          />
-        </svg>
-      ) : (
-        // Moon icon for switching to dark
-        <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={1.5}
-            d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"
-          />
-        </svg>
-      )}
-    </button>
-  );
-}
-
-function GitHubIcon() {
-  return (
-    <a
-      href="https://github.com/emily-flambe/mesearch"
-      target="_blank"
-      rel="noopener noreferrer"
-      className="text-[var(--color-text-muted)] hover:text-[var(--color-champagne)] transition-colors duration-300"
-      aria-label="View on GitHub"
-    >
-      <svg
-        viewBox="0 0 24 24"
-        width="22"
-        height="22"
-        fill="currentColor"
-        aria-hidden="true"
-      >
-        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-      </svg>
-    </a>
-  );
-}
-
 function HomePage() {
   const { flags } = useFeatureFlags();
 
   return (
-    <div id="top" className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-      {/* Header */}
-      <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md sticky top-0 z-50 transition-colors duration-300">
-        <div className="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
-          <a href="#top" className="font-display text-2xl font-semibold tracking-wide text-gold-gradient">
-            Mesearch
-          </a>
-          <nav className="flex items-center gap-6">
-            <a
-              href="#tests"
-              className="text-[var(--color-text-secondary)] hover:text-[var(--color-champagne)] transition-colors duration-300 text-sm tracking-wide uppercase"
-            >
-              Tests
-            </a>
-            <a
-              href="#about"
-              className="text-[var(--color-text-secondary)] hover:text-[var(--color-champagne)] transition-colors duration-300 text-sm tracking-wide uppercase"
-            >
-              About
-            </a>
-            <div className="w-px h-5 bg-[var(--color-border)]" />
-            <UserMenu />
-            <ThemeToggle />
-            <GitHubIcon />
-          </nav>
-        </div>
-      </header>
-
+    <Layout>
       <main>
         {/* Hero Section */}
         <section className="relative mx-auto max-w-6xl px-6 py-32 text-center overflow-hidden">
@@ -383,7 +254,7 @@ function HomePage() {
           <p className="text-[var(--color-text-muted)]/50 text-xs">&copy; 2026</p>
         </div>
       </footer>
-    </div>
+    </Layout>
   );
 }
 
@@ -460,21 +331,7 @@ function TestCard({
 // Generic placeholder for tests not yet implemented
 function ComingSoonTestPage() {
   return (
-    <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-      {/* Header */}
-      <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
-        <div className="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
-          <Link to="/" className="font-display text-2xl font-semibold tracking-wide text-gold-gradient">
-            Mesearch
-          </Link>
-          <div className="flex items-center gap-4">
-            <ThemeToggle />
-            <GitHubIcon />
-          </div>
-        </div>
-      </header>
-
-      {/* Content */}
+    <Layout>
       <main className="mx-auto max-w-2xl px-6 py-24 text-center">
         <div className="card-premium rounded-lg p-12">
           <div className="w-16 h-16 mx-auto mb-8 rounded-full border border-[var(--color-champagne)]/30 flex items-center justify-center">
@@ -506,7 +363,7 @@ function ComingSoonTestPage() {
           </Link>
         </div>
       </main>
-    </div>
+    </Layout>
   );
 }
 
@@ -580,20 +437,7 @@ function EnneagramTestPage() {
   };
 
   return (
-    <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-      {/* Header */}
-      <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
-        <div className="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
-          <Link to="/" className="font-display text-2xl font-semibold tracking-wide text-gold-gradient">
-            Mesearch
-          </Link>
-          <div className="flex items-center gap-4">
-            <ThemeToggle />
-            <GitHubIcon />
-          </div>
-        </div>
-      </header>
-
+    <Layout>
       <main className="mx-auto max-w-3xl px-6 py-12">
         {phase === 'intro' && (
           <div className="text-center">
@@ -721,7 +565,7 @@ function EnneagramTestPage() {
           <EnneagramResults result={result} onRetake={handleRetake} />
         )}
       </main>
-    </div>
+    </Layout>
   );
 }
 

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -64,41 +64,6 @@ function HomePage() {
             Explore Tests
           </Link>
         </section>
-
-        {/* Divider */}
-        <div className="divider-elegant mx-auto max-w-md" />
-
-        {/* About Section */}
-        <section id="about" className="relative py-24 overflow-hidden scroll-mt-24">
-          <div className="absolute inset-0 bg-gradient-to-b from-[var(--color-bg-primary)] via-[var(--color-accent-purple)] to-[var(--color-bg-primary)] opacity-50 transition-colors duration-300" />
-          <div className="relative mx-auto max-w-6xl px-6 text-center">
-            <p className="text-[var(--color-champagne)] text-xs tracking-[0.3em] uppercase mb-4">Methodology</p>
-            <h3 className="font-display text-4xl font-medium text-[var(--color-text-primary)] mb-6 transition-colors duration-300">
-              The Science Behind It
-            </h3>
-            <p className="text-[var(--color-text-secondary)] text-lg max-w-2xl mx-auto mb-12 leading-relaxed font-light transition-colors duration-300">
-              Each test is rated on two dimensions: Seriousness reflects the depth of research
-              supporting its validity, while Fun captures how engaging the experience is.
-              Some tests excel at both. Some tests are dogshit. We decide, you report!
-            </p>
-            <div className="flex justify-center gap-16">
-              <div className="text-center">
-                <div className="flex items-center justify-center gap-2 mb-3">
-                  <span className="text-[var(--color-text-secondary)] text-sm">Seriousness</span>
-                  <RatingDots value={5} />
-                </div>
-                <p className="text-[var(--color-text-muted)] text-sm transition-colors duration-300">Strong empirical support</p>
-              </div>
-              <div className="text-center">
-                <div className="flex items-center justify-center gap-2 mb-3">
-                  <span className="text-[var(--color-text-secondary)] text-sm">Fun</span>
-                  <RatingDots value={5} />
-                </div>
-                <p className="text-[var(--color-text-muted)] text-sm transition-colors duration-300">Engaging and enjoyable</p>
-              </div>
-            </div>
-          </div>
-        </section>
       </main>
 
       {/* Footer */}
@@ -109,23 +74,6 @@ function HomePage() {
         </div>
       </footer>
     </Layout>
-  );
-}
-
-function RatingDots({ value, max = 5 }: { value: number; max?: number }) {
-  return (
-    <div className="flex gap-1">
-      {Array.from({ length: max }).map((_, i) => (
-        <div
-          key={i}
-          className={`w-1.5 h-1.5 rounded-full ${
-            i < value
-              ? 'bg-[var(--color-champagne)]'
-              : 'bg-[var(--color-border)]'
-          }`}
-        />
-      ))}
-    </div>
   );
 }
 

--- a/frontend/components/BigFiveAssessment.tsx
+++ b/frontend/components/BigFiveAssessment.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
+import { Layout } from './Layout';
 import { items, shuffleItems, type Item } from '../data/big-five-items';
 import {
   type Response,
@@ -116,8 +117,7 @@ export default function BigFiveAssessment() {
   // Render intro phase
   if (phase === 'intro') {
     return (
-      <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-        <Header />
+      <Layout>
         <main className="mx-auto max-w-2xl px-6 py-16">
           <div className="card-premium rounded-lg p-10">
             <div className="text-center mb-8">
@@ -184,15 +184,14 @@ export default function BigFiveAssessment() {
             </div>
           </div>
         </main>
-      </div>
+      </Layout>
     );
   }
 
   // Render completion phase
   if (phase === 'complete') {
     return (
-      <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-        <Header />
+      <Layout>
         <main className="mx-auto max-w-2xl px-6 py-16">
           <div className="card-premium rounded-lg p-10 text-center">
             <div className="w-16 h-16 mx-auto mb-6 rounded-full border-2 border-[var(--color-champagne)] flex items-center justify-center">
@@ -227,7 +226,7 @@ export default function BigFiveAssessment() {
             </button>
           </div>
         </main>
-      </div>
+      </Layout>
     );
   }
 
@@ -321,20 +320,5 @@ export default function BigFiveAssessment() {
         </div>
       </footer>
     </div>
-  );
-}
-
-function Header() {
-  return (
-    <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
-      <div className="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
-        <Link
-          to="/"
-          className="font-display text-2xl font-semibold tracking-wide text-gold-gradient"
-        >
-          Mēsearch
-        </Link>
-      </div>
-    </header>
   );
 }

--- a/frontend/components/BigFiveResults.tsx
+++ b/frontend/components/BigFiveResults.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import { Layout } from './Layout';
 import {
   type BigFiveResults as Results,
   type DimensionScore,
@@ -34,27 +35,26 @@ export default function BigFiveResults({ initialResults, showHeader = true, show
   }, [initialResults]);
 
   if (!results) {
-    return (
-      <div className={showHeader ? "min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300" : ""}>
-        {showHeader && <Header />}
-        <main className="mx-auto max-w-2xl px-6 py-16 text-center">
-          <div className="card-premium rounded-lg p-10">
-            <h2 className="font-display text-2xl font-medium text-[var(--color-text-primary)] mb-4">
-              No Results Found
-            </h2>
-            <p className="text-[var(--color-text-secondary)] mb-8">
-              You haven&apos;t completed the Big Five assessment yet.
-            </p>
-            <button
-              onClick={() => navigate('/test/big-five')}
-              className="btn-gold px-8 py-3 rounded text-sm tracking-widest uppercase"
-            >
-              Take the Test
-            </button>
-          </div>
-        </main>
-      </div>
+    const content = (
+      <main className="mx-auto max-w-2xl px-6 py-16 text-center">
+        <div className="card-premium rounded-lg p-10">
+          <h2 className="font-display text-2xl font-medium text-[var(--color-text-primary)] mb-4">
+            No Results Found
+          </h2>
+          <p className="text-[var(--color-text-secondary)] mb-8">
+            You haven&apos;t completed the Big Five assessment yet.
+          </p>
+          <button
+            onClick={() => navigate('/test/big-five')}
+            className="btn-gold px-8 py-3 rounded text-sm tracking-widest uppercase"
+          >
+            Take the Test
+          </button>
+        </div>
+      </main>
     );
+
+    return showHeader ? <Layout>{content}</Layout> : content;
   }
 
   const dimensionScores = results.dimensions;
@@ -92,12 +92,10 @@ export default function BigFiveResults({ initialResults, showHeader = true, show
     );
   }
 
-  return (
-    <div className={showHeader ? "min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300" : ""}>
-      {showHeader && <Header />}
-      <main className="mx-auto max-w-4xl px-6 py-12">
-        {/* Title */}
-        <div className="text-center mb-12">
+  const mainContent = (
+    <main className="mx-auto max-w-4xl px-6 py-12">
+      {/* Title */}
+      <div className="text-center mb-12">
           <p className="text-[var(--color-champagne)] text-xs tracking-[0.3em] uppercase mb-4">
             Your Results
           </p>
@@ -153,36 +151,22 @@ export default function BigFiveResults({ initialResults, showHeader = true, show
           </div>
         )}
 
-        {/* Disclaimer */}
-        <div className="mt-12 text-center">
-          <p className="text-[var(--color-text-muted)] text-xs leading-relaxed max-w-2xl mx-auto">
-            This assessment provides a snapshot of your personality based on self-reported responses.
-            Results should be used for self-reflection and personal growth, not as clinical diagnoses.
-            Personality can be influenced by context and may change over time.
-          </p>
-        </div>
-      </main>
-    </div>
+      {/* Disclaimer */}
+      <div className="mt-12 text-center">
+        <p className="text-[var(--color-text-muted)] text-xs leading-relaxed max-w-2xl mx-auto">
+          This assessment provides a snapshot of your personality based on self-reported responses.
+          Results should be used for self-reflection and personal growth, not as clinical diagnoses.
+          Personality can be influenced by context and may change over time.
+        </p>
+      </div>
+    </main>
   );
+
+  return showHeader ? <Layout>{mainContent}</Layout> : mainContent;
 }
 
 // Export the Results type for use in ResultDetail
 export type { Results as BigFiveResultsType };
-
-function Header() {
-  return (
-    <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
-      <div className="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
-        <Link
-          to="/"
-          className="font-display text-2xl font-semibold tracking-wide text-gold-gradient"
-        >
-          Mēsearch
-        </Link>
-      </div>
-    </header>
-  );
-}
 
 interface RadarChartProps {
   scores: DimensionScore[];

--- a/frontend/components/CRTAssessment.tsx
+++ b/frontend/components/CRTAssessment.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import { Layout } from './Layout';
 import { crtItems, priorExposureOptions, type PriorExposure } from '../data/crt-items';
 import {
   calculateCRTScores,
@@ -157,8 +158,7 @@ export default function CRTAssessment() {
   // Render intro phase
   if (phase === 'intro') {
     return (
-      <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-        <Header />
+      <Layout>
         <main className="mx-auto max-w-2xl px-6 py-16">
           <div className="card-premium rounded-lg p-10">
             <div className="text-center mb-8">
@@ -224,15 +224,14 @@ export default function CRTAssessment() {
             </div>
           </div>
         </main>
-      </div>
+      </Layout>
     );
   }
 
   // Render prior exposure phase
   if (phase === 'prior-exposure') {
     return (
-      <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-        <Header />
+      <Layout>
         <main className="mx-auto max-w-2xl px-6 py-16">
           <div className="card-premium rounded-lg p-10">
             <div className="text-center mb-8">
@@ -263,19 +262,18 @@ export default function CRTAssessment() {
             </div>
           </div>
         </main>
-      </div>
+      </Layout>
     );
   }
 
   // Render results phase
   if (phase === 'results' && results) {
     return (
-      <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-        <Header />
+      <Layout>
         <main className="mx-auto max-w-4xl px-6 py-12">
           <CRTResultsComponent results={results} onRetake={handleRetake} />
         </main>
-      </div>
+      </Layout>
     );
   }
 
@@ -384,20 +382,5 @@ export default function CRTAssessment() {
         </div>
       </footer>
     </div>
-  );
-}
-
-function Header() {
-  return (
-    <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
-      <div className="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
-        <Link
-          to="/"
-          className="font-display text-2xl font-semibold tracking-wide text-gold-gradient"
-        >
-          Mesearch
-        </Link>
-      </div>
-    </header>
   );
 }

--- a/frontend/components/ECRAssessment.tsx
+++ b/frontend/components/ECRAssessment.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
+import { Layout } from './Layout';
 import { items, likertScale, type Item, type LikertValue } from '../data/ecr-items';
 import {
   type Response,
@@ -134,8 +135,7 @@ export default function ECRAssessment() {
   // Render intro phase
   if (phase === 'intro') {
     return (
-      <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-        <Header />
+      <Layout>
         <main className="mx-auto max-w-2xl px-6 py-16">
           <div className="card-premium rounded-lg p-10">
             <div className="text-center mb-8">
@@ -213,15 +213,14 @@ export default function ECRAssessment() {
             </div>
           </div>
         </main>
-      </div>
+      </Layout>
     );
   }
 
   // Render completion phase
   if (phase === 'complete') {
     return (
-      <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-        <Header />
+      <Layout>
         <main className="mx-auto max-w-2xl px-6 py-16">
           <div className="card-premium rounded-lg p-10 text-center">
             <div className="w-16 h-16 mx-auto mb-6 rounded-full border-2 border-[var(--color-champagne)] flex items-center justify-center">
@@ -257,7 +256,7 @@ export default function ECRAssessment() {
             </button>
           </div>
         </main>
-      </div>
+      </Layout>
     );
   }
 
@@ -356,20 +355,5 @@ export default function ECRAssessment() {
         </div>
       </footer>
     </div>
-  );
-}
-
-function Header() {
-  return (
-    <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
-      <div className="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
-        <Link
-          to="/"
-          className="font-display text-2xl font-semibold tracking-wide text-gold-gradient"
-        >
-          Mesearch
-        </Link>
-      </div>
-    </header>
   );
 }

--- a/frontend/components/ECRResults.tsx
+++ b/frontend/components/ECRResults.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import { Layout } from './Layout';
 import {
   type ECRResults as Results,
   deserializeResults,
@@ -34,38 +35,35 @@ export default function ECRResults({ initialResults, showHeader = true, showActi
   }, [initialResults]);
 
   if (!results) {
-    return (
-      <div className={showHeader ? "min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300" : ""}>
-        {showHeader && <Header />}
-        <main className="mx-auto max-w-2xl px-6 py-16 text-center">
-          <div className="card-premium rounded-lg p-10">
-            <h2 className="font-display text-2xl font-medium text-[var(--color-text-primary)] mb-4">
-              No Results Found
-            </h2>
-            <p className="text-[var(--color-text-secondary)] mb-8">
-              You haven&apos;t completed the Attachment Style assessment yet.
-            </p>
-            <button
-              onClick={() => navigate('/test/ecr')}
-              className="btn-gold px-8 py-3 rounded text-sm tracking-widest uppercase"
-            >
-              Take the Test
-            </button>
-          </div>
-        </main>
-      </div>
+    const content = (
+      <main className="mx-auto max-w-2xl px-6 py-16 text-center">
+        <div className="card-premium rounded-lg p-10">
+          <h2 className="font-display text-2xl font-medium text-[var(--color-text-primary)] mb-4">
+            No Results Found
+          </h2>
+          <p className="text-[var(--color-text-secondary)] mb-8">
+            You haven&apos;t completed the Attachment Style assessment yet.
+          </p>
+          <button
+            onClick={() => navigate('/test/ecr')}
+            className="btn-gold px-8 py-3 rounded text-sm tracking-widest uppercase"
+          >
+            Take the Test
+          </button>
+        </div>
+      </main>
     );
+
+    return showHeader ? <Layout>{content}</Layout> : content;
   }
 
   const { anxiety, avoidance, suggestedStyle } = results;
   const styleInfo = attachmentStyleInfo[suggestedStyle];
 
-  return (
-    <div className={showHeader ? "min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300" : ""}>
-      {showHeader && <Header />}
-      <main className="mx-auto max-w-4xl px-6 py-12">
-        {/* Title */}
-        <div className="text-center mb-12">
+  const mainContent = (
+    <main className="mx-auto max-w-4xl px-6 py-12">
+      {/* Title */}
+      <div className="text-center mb-12">
           <p className="text-[var(--color-champagne)] text-xs tracking-[0.3em] uppercase mb-4">
             Your Results
           </p>
@@ -207,41 +205,27 @@ export default function ECRResults({ initialResults, showHeader = true, showActi
           </p>
         </div>
 
-        {/* Actions */}
-        {showActions && (
-          <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <button
-              onClick={() => navigate('/test/ecr')}
-              className="btn-ghost px-8 py-3 rounded text-sm tracking-widest uppercase"
-            >
-              Retake Test
-            </button>
-            <Link
-              to="/"
-              className="btn-gold px-8 py-3 rounded text-sm tracking-widest uppercase text-center"
-            >
-              Explore More Tests
-            </Link>
-          </div>
-        )}
-      </main>
-    </div>
+      {/* Actions */}
+      {showActions && (
+        <div className="flex flex-col sm:flex-row gap-4 justify-center">
+          <button
+            onClick={() => navigate('/test/ecr')}
+            className="btn-ghost px-8 py-3 rounded text-sm tracking-widest uppercase"
+          >
+            Retake Test
+          </button>
+          <Link
+            to="/"
+            className="btn-gold px-8 py-3 rounded text-sm tracking-widest uppercase text-center"
+          >
+            Explore More Tests
+          </Link>
+        </div>
+      )}
+    </main>
   );
-}
 
-function Header() {
-  return (
-    <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
-      <div className="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
-        <Link
-          to="/"
-          className="font-display text-2xl font-semibold tracking-wide text-gold-gradient"
-        >
-          Mesearch
-        </Link>
-      </div>
-    </header>
-  );
+  return showHeader ? <Layout>{mainContent}</Layout> : mainContent;
 }
 
 interface AttachmentPlotProps {

--- a/frontend/components/HexacoAssessment.tsx
+++ b/frontend/components/HexacoAssessment.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import { Layout } from './Layout';
 import { hexacoItems } from '../data/hexaco-items';
 import { HexacoResponse, getProgress } from '../data/hexaco-scoring';
 
@@ -76,22 +77,7 @@ export default function HexacoAssessment({ onComplete }: HexacoAssessmentProps) 
   };
 
   return (
-    <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-      {/* Minimal Header */}
-      <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
-        <div className="mx-auto max-w-4xl px-6 py-4 flex items-center justify-between">
-          <Link
-            to="/"
-            className="font-display text-xl font-semibold tracking-wide text-gold-gradient"
-          >
-            Mēsearch
-          </Link>
-          <span className="text-[var(--color-text-muted)] text-sm">
-            HEXACO-60 Assessment
-          </span>
-        </div>
-      </header>
-
+    <Layout>
       {/* Progress Bar */}
       <div className="bg-[var(--color-bg-secondary)] border-b border-[var(--color-border-subtle)]">
         <div className="mx-auto max-w-4xl px-6 py-3">
@@ -209,6 +195,6 @@ export default function HexacoAssessment({ onComplete }: HexacoAssessmentProps) 
           There are no right or wrong answers.
         </p>
       </main>
-    </div>
+    </Layout>
   );
 }

--- a/frontend/components/HexacoResults.tsx
+++ b/frontend/components/HexacoResults.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { Link } from 'react-router-dom';
+import { Layout } from './Layout';
 import {
   DimensionScore,
   scoreToPercentage,
@@ -139,41 +140,29 @@ export default function HexacoResults({ scores, showHeader = true, showActions =
   }, []);
 
   if (!scores) {
-    return (
-      <div className={showHeader ? "min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300" : ""}>
-        {showHeader && (
-          <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
-            <div className="mx-auto max-w-6xl px-6 py-5">
-              <Link
-                to="/"
-                className="font-display text-2xl font-semibold tracking-wide text-gold-gradient"
-              >
-                Mēsearch
-              </Link>
-            </div>
-          </header>
-        )}
-        <main className="mx-auto max-w-2xl px-6 py-24 text-center">
-          <div className="card-premium rounded-lg p-12">
-            <p className="text-[var(--color-champagne)] text-xs tracking-[0.3em] uppercase mb-4">
-              No Results Found
-            </p>
-            <h2 className="font-display text-3xl font-medium text-[var(--color-text-primary)] mb-4 transition-colors duration-300">
-              Assessment Incomplete
-            </h2>
-            <p className="text-[var(--color-text-secondary)] mb-10 leading-relaxed transition-colors duration-300">
-              Please complete the HEXACO-60 assessment to view your results.
-            </p>
-            <Link
-              to="/hexaco"
-              className="btn-gold inline-block px-8 py-3 rounded text-xs tracking-widest uppercase"
-            >
-              Start Assessment
-            </Link>
-          </div>
-        </main>
-      </div>
+    const content = (
+      <main className="mx-auto max-w-2xl px-6 py-24 text-center">
+        <div className="card-premium rounded-lg p-12">
+          <p className="text-[var(--color-champagne)] text-xs tracking-[0.3em] uppercase mb-4">
+            No Results Found
+          </p>
+          <h2 className="font-display text-3xl font-medium text-[var(--color-text-primary)] mb-4 transition-colors duration-300">
+            Assessment Incomplete
+          </h2>
+          <p className="text-[var(--color-text-secondary)] mb-10 leading-relaxed transition-colors duration-300">
+            Please complete the HEXACO-60 assessment to view your results.
+          </p>
+          <Link
+            to="/hexaco"
+            className="btn-gold inline-block px-8 py-3 rounded text-xs tracking-widest uppercase"
+          >
+            Start Assessment
+          </Link>
+        </div>
+      </main>
     );
+
+    return showHeader ? <Layout>{content}</Layout> : content;
   }
 
   // Reorder to put Honesty-Humility first (as the unique HEXACO insight)
@@ -183,28 +172,8 @@ export default function HexacoResults({ scores, showHeader = true, showActions =
     return 0;
   });
 
-  return (
-    <div className={showHeader ? "min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300" : ""}>
-      {/* Header */}
-      {showHeader && (
-        <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md sticky top-0 z-50 transition-colors duration-300">
-          <div className="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
-            <Link
-              to="/"
-              className="font-display text-2xl font-semibold tracking-wide text-gold-gradient"
-            >
-              Mēsearch
-            </Link>
-            <Link
-              to="/"
-              className="text-[var(--color-text-secondary)] hover:text-[var(--color-champagne)] transition-colors duration-300 text-sm tracking-wide"
-            >
-              Back to Home
-            </Link>
-          </div>
-        </header>
-      )}
-
+  const mainContent = (
+    <>
       <main className="mx-auto max-w-4xl px-6 py-12">
         {/* Results Header */}
         <div className="text-center mb-12">
@@ -313,7 +282,7 @@ export default function HexacoResults({ scores, showHeader = true, showActions =
       {showHeader && (
         <footer className="border-t border-[var(--color-border)] py-12 mt-12 transition-colors duration-300">
           <div className="mx-auto max-w-6xl px-6 text-center">
-            <p className="font-display text-xl text-gold-gradient mb-4">Mēsearch</p>
+            <p className="font-display text-xl text-gold-gradient mb-4">Mesearch</p>
             <p className="text-[var(--color-text-muted)] text-xs mb-2">
               HEXACO-60 is copyrighted by K. Lee & M.C. Ashton
             </p>
@@ -321,6 +290,8 @@ export default function HexacoResults({ scores, showHeader = true, showActions =
           </div>
         </footer>
       )}
-    </div>
+    </>
   );
+
+  return showHeader ? <Layout>{mainContent}</Layout> : mainContent;
 }

--- a/frontend/components/Layout.tsx
+++ b/frontend/components/Layout.tsx
@@ -115,7 +115,7 @@ export function Layout({ children }: LayoutProps) {
           </Link>
           <nav className="flex items-center gap-6">
             <Link
-              to="/#tests"
+              to="/tests"
               className="text-[var(--color-text-secondary)] hover:text-[var(--color-champagne)] transition-colors duration-300 text-sm tracking-wide uppercase"
             >
               Tests

--- a/frontend/components/Layout.tsx
+++ b/frontend/components/Layout.tsx
@@ -79,28 +79,6 @@ function ThemeToggle() {
   );
 }
 
-function GitHubIcon() {
-  return (
-    <a
-      href="https://github.com/emily-flambe/mesearch"
-      target="_blank"
-      rel="noopener noreferrer"
-      className="text-[var(--color-text-muted)] hover:text-[var(--color-champagne)] transition-colors duration-300"
-      aria-label="View on GitHub"
-    >
-      <svg
-        viewBox="0 0 24 24"
-        width="22"
-        height="22"
-        fill="currentColor"
-        aria-hidden="true"
-      >
-        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-      </svg>
-    </a>
-  );
-}
-
 interface LayoutProps {
   children: React.ReactNode;
 }
@@ -129,7 +107,6 @@ export function Layout({ children }: LayoutProps) {
             <div className="w-px h-5 bg-[var(--color-border)]" />
             <UserMenu />
             <ThemeToggle />
-            <GitHubIcon />
           </nav>
         </div>
       </header>

--- a/frontend/components/Layout.tsx
+++ b/frontend/components/Layout.tsx
@@ -1,0 +1,139 @@
+import { Link } from 'react-router-dom';
+import { UserMenu } from './UserMenu';
+import { createContext, useContext, useEffect, useState } from 'react';
+
+// Theme Context
+type Theme = 'dark' | 'light';
+
+const ThemeContext = createContext<{
+  theme: Theme;
+  toggleTheme: () => void;
+}>({
+  theme: 'dark',
+  toggleTheme: () => {},
+});
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window !== 'undefined') {
+      const saved = localStorage.getItem('mesearch-theme');
+      return (saved as Theme) || 'dark';
+    }
+    return 'dark';
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === 'light') {
+      root.classList.add('light');
+    } else {
+      root.classList.remove('light');
+    }
+    localStorage.setItem('mesearch-theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'));
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}
+
+function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className="theme-toggle"
+      aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+    >
+      {theme === 'dark' ? (
+        <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.5}
+            d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"
+          />
+        </svg>
+      ) : (
+        <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.5}
+            d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"
+          />
+        </svg>
+      )}
+    </button>
+  );
+}
+
+function GitHubIcon() {
+  return (
+    <a
+      href="https://github.com/emily-flambe/mesearch"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-[var(--color-text-muted)] hover:text-[var(--color-champagne)] transition-colors duration-300"
+      aria-label="View on GitHub"
+    >
+      <svg
+        viewBox="0 0 24 24"
+        width="22"
+        height="22"
+        fill="currentColor"
+        aria-hidden="true"
+      >
+        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+      </svg>
+    </a>
+  );
+}
+
+interface LayoutProps {
+  children: React.ReactNode;
+}
+
+export function Layout({ children }: LayoutProps) {
+  return (
+    <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
+      <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md sticky top-0 z-50 transition-colors duration-300">
+        <div className="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
+          <Link to="/" className="font-display text-2xl font-semibold tracking-wide text-gold-gradient">
+            Mesearch
+          </Link>
+          <nav className="flex items-center gap-6">
+            <Link
+              to="/#tests"
+              className="text-[var(--color-text-secondary)] hover:text-[var(--color-champagne)] transition-colors duration-300 text-sm tracking-wide uppercase"
+            >
+              Tests
+            </Link>
+            <Link
+              to="/my-results"
+              className="text-[var(--color-text-secondary)] hover:text-[var(--color-champagne)] transition-colors duration-300 text-sm tracking-wide uppercase"
+            >
+              Results
+            </Link>
+            <div className="w-px h-5 bg-[var(--color-border)]" />
+            <UserMenu />
+            <ThemeToggle />
+            <GitHubIcon />
+          </nav>
+        </div>
+      </header>
+      {children}
+    </div>
+  );
+}

--- a/frontend/components/LoveLanguagesAssessment.tsx
+++ b/frontend/components/LoveLanguagesAssessment.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
+import { Layout } from './Layout';
 import { items, shuffleItems, type ForcedChoiceItem } from '../data/love-languages-items';
 import {
   type ForcedChoiceResponse,
@@ -139,8 +140,7 @@ export default function LoveLanguagesAssessment() {
   // Render intro phase
   if (phase === 'intro') {
     return (
-      <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-        <Header />
+      <Layout>
         <main className="mx-auto max-w-2xl px-6 py-16">
           <div className="card-premium rounded-lg p-10">
             <div className="text-center mb-8">
@@ -233,15 +233,14 @@ export default function LoveLanguagesAssessment() {
             </div>
           </div>
         </main>
-      </div>
+      </Layout>
     );
   }
 
   // Render completion phase
   if (phase === 'complete') {
     return (
-      <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-        <Header />
+      <Layout>
         <main className="mx-auto max-w-2xl px-6 py-16">
           <div className="card-premium rounded-lg p-10 text-center">
             <div className="w-16 h-16 mx-auto mb-6 rounded-full border-2 border-[var(--color-champagne)] flex items-center justify-center">
@@ -277,7 +276,7 @@ export default function LoveLanguagesAssessment() {
             </button>
           </div>
         </main>
-      </div>
+      </Layout>
     );
   }
 
@@ -397,20 +396,5 @@ export default function LoveLanguagesAssessment() {
         </div>
       </footer>
     </div>
-  );
-}
-
-function Header() {
-  return (
-    <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
-      <div className="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
-        <Link
-          to="/"
-          className="font-display text-2xl font-semibold tracking-wide text-gold-gradient"
-        >
-          Mesearch
-        </Link>
-      </div>
-    </header>
   );
 }

--- a/frontend/components/LoveLanguagesResults.tsx
+++ b/frontend/components/LoveLanguagesResults.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import { Layout } from './Layout';
 import {
   type CommunicationStylesResults,
   deserializeResults,
@@ -40,33 +41,19 @@ export default function LoveLanguagesResults({ initialResults, showHeader = true
   }, [navigate, initialResults]);
 
   if (!results) {
-    return (
-      <div className={showHeader ? "min-h-screen bg-[var(--color-bg-primary)] flex items-center justify-center" : ""}>
-        <div className="text-[var(--color-text-muted)]">Loading results...</div>
-      </div>
-    );
+    const loading = <div className="text-[var(--color-text-muted)]">Loading results...</div>;
+    return showHeader ? (
+      <Layout>
+        <div className="min-h-[50vh] flex items-center justify-center">{loading}</div>
+      </Layout>
+    ) : loading;
   }
 
   const primaryStyle = styleInfo[results.primary];
   const secondaryStyle = styleInfo[results.secondary];
 
-  return (
-    <div className={showHeader ? "min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300" : ""}>
-      {/* Header */}
-      {showHeader && (
-        <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
-          <div className="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
-            <Link
-              to="/"
-              className="font-display text-2xl font-semibold tracking-wide text-gold-gradient"
-            >
-              Mesearch
-            </Link>
-          </div>
-        </header>
-      )}
-
-      <main className="mx-auto max-w-3xl px-6 py-12" data-testid="love-languages-results">
+  const mainContent = (
+    <main className="mx-auto max-w-3xl px-6 py-12" data-testid="love-languages-results">
         {/* Results Header */}
         <div className="text-center mb-12">
           <p className="text-[var(--color-champagne)] text-xs tracking-[0.3em] uppercase mb-4">
@@ -261,24 +248,25 @@ export default function LoveLanguagesResults({ initialResults, showHeader = true
           </p>
         </div>
 
-        {/* Actions */}
-        {showActions && (
-          <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Link
-              to="/test/communication-styles"
-              className="btn-ghost px-8 py-4 rounded text-sm tracking-widest uppercase text-center"
-            >
-              Retake Assessment
-            </Link>
-            <Link
-              to="/"
-              className="btn-gold px-8 py-4 rounded text-sm tracking-widest uppercase text-center"
-            >
-              Return Home
-            </Link>
-          </div>
-        )}
-      </main>
-    </div>
+      {/* Actions */}
+      {showActions && (
+        <div className="flex flex-col sm:flex-row gap-4 justify-center">
+          <Link
+            to="/test/communication-styles"
+            className="btn-ghost px-8 py-4 rounded text-sm tracking-widest uppercase text-center"
+          >
+            Retake Assessment
+          </Link>
+          <Link
+            to="/"
+            className="btn-gold px-8 py-4 rounded text-sm tracking-widest uppercase text-center"
+          >
+            Return Home
+          </Link>
+        </div>
+      )}
+    </main>
   );
+
+  return showHeader ? <Layout>{mainContent}</Layout> : mainContent;
 }

--- a/frontend/components/MBTIAssessment.tsx
+++ b/frontend/components/MBTIAssessment.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
+import { Layout } from './Layout';
 import { useAuth } from '../contexts/AuthContext';
 import { items, shuffleItems, type Item } from '../data/mbti-items';
 import {
@@ -141,8 +142,7 @@ export default function MBTIAssessment() {
   // Render intro phase
   if (phase === 'intro') {
     return (
-      <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-        <Header />
+      <Layout>
         <main className="mx-auto max-w-2xl px-6 py-16">
           <div className="card-premium rounded-lg p-10">
             <div className="text-center mb-8">
@@ -224,15 +224,14 @@ export default function MBTIAssessment() {
             </div>
           </div>
         </main>
-      </div>
+      </Layout>
     );
   }
 
   // Render completion phase
   if (phase === 'complete') {
     return (
-      <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-        <Header />
+      <Layout>
         <main className="mx-auto max-w-2xl px-6 py-16">
           <div className="card-premium rounded-lg p-10 text-center">
             <div className="w-16 h-16 mx-auto mb-6 rounded-full border-2 border-[var(--color-champagne)] flex items-center justify-center">
@@ -279,7 +278,7 @@ export default function MBTIAssessment() {
             </button>
           </div>
         </main>
-      </div>
+      </Layout>
     );
   }
 
@@ -404,20 +403,5 @@ export default function MBTIAssessment() {
         </div>
       </footer>
     </div>
-  );
-}
-
-function Header() {
-  return (
-    <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
-      <div className="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
-        <Link
-          to="/"
-          className="font-display text-2xl font-semibold tracking-wide text-gold-gradient"
-        >
-          Mesearch
-        </Link>
-      </div>
-    </header>
   );
 }

--- a/frontend/components/MBTIResults.tsx
+++ b/frontend/components/MBTIResults.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import { Layout } from './Layout';
 import {
   type MBTIResults as Results,
   type DimensionScore,
@@ -35,27 +36,26 @@ export default function MBTIResults({ initialResults, showHeader = true, showAct
   }, [initialResults]);
 
   if (!results) {
-    return (
-      <div className={showHeader ? "min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300" : ""}>
-        {showHeader && <Header />}
-        <main className="mx-auto max-w-2xl px-6 py-16 text-center">
-          <div className="card-premium rounded-lg p-10">
-            <h2 className="font-display text-2xl font-medium text-[var(--color-text-primary)] mb-4">
-              No Results Found
-            </h2>
-            <p className="text-[var(--color-text-secondary)] mb-8">
-              You haven&apos;t completed the Myers-Briggs style assessment yet.
-            </p>
-            <button
-              onClick={() => navigate('/test/mbti')}
-              className="btn-gold px-8 py-3 rounded text-sm tracking-widest uppercase"
-            >
-              Take the Test
-            </button>
-          </div>
-        </main>
-      </div>
+    const content = (
+      <main className="mx-auto max-w-2xl px-6 py-16 text-center">
+        <div className="card-premium rounded-lg p-10">
+          <h2 className="font-display text-2xl font-medium text-[var(--color-text-primary)] mb-4">
+            No Results Found
+          </h2>
+          <p className="text-[var(--color-text-secondary)] mb-8">
+            You haven&apos;t completed the Myers-Briggs style assessment yet.
+          </p>
+          <button
+            onClick={() => navigate('/test/mbti')}
+            className="btn-gold px-8 py-3 rounded text-sm tracking-widest uppercase"
+          >
+            Take the Test
+          </button>
+        </div>
+      </main>
     );
+
+    return showHeader ? <Layout>{content}</Layout> : content;
   }
 
   const typeInfo = typeDescriptions[results.type] || {
@@ -63,13 +63,8 @@ export default function MBTIResults({ initialResults, showHeader = true, showAct
     description: 'A unique combination of cognitive preferences.',
   };
 
-  return (
-    <div
-      className={showHeader ? "min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300" : ""}
-      data-testid="mbti-results"
-    >
-      {showHeader && <Header />}
-      <main className="mx-auto max-w-4xl px-6 py-12">
+  const mainContent = (
+    <main className="mx-auto max-w-4xl px-6 py-12" data-testid="mbti-results">
         {/* Title */}
         <div className="text-center mb-12">
           <p className="text-[var(--color-champagne)] text-xs tracking-[0.3em] uppercase mb-4">
@@ -150,39 +145,25 @@ export default function MBTIResults({ initialResults, showHeader = true, showAct
           </div>
         )}
 
-        {/* Attribution */}
-        <div className="mt-12 text-center">
-          <p className="text-[var(--color-text-muted)] text-xs leading-relaxed max-w-2xl mx-auto">
-            Based on the Open Extended Jungian Type Scales (OEJTS) by Eric Jorgenson at Open
-            Psychometrics. Licensed under Creative Commons.{' '}
-            <a
-              href="https://openpsychometrics.org/tests/OEJTS/"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-[var(--color-champagne)] hover:underline"
-            >
-              Learn more
-            </a>
-          </p>
-        </div>
-      </main>
-    </div>
-  );
-}
-
-function Header() {
-  return (
-    <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
-      <div className="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
-        <Link
-          to="/"
-          className="font-display text-2xl font-semibold tracking-wide text-gold-gradient"
-        >
-          Mesearch
-        </Link>
+      {/* Attribution */}
+      <div className="mt-12 text-center">
+        <p className="text-[var(--color-text-muted)] text-xs leading-relaxed max-w-2xl mx-auto">
+          Based on the Open Extended Jungian Type Scales (OEJTS) by Eric Jorgenson at Open
+          Psychometrics. Licensed under Creative Commons.{' '}
+          <a
+            href="https://openpsychometrics.org/tests/OEJTS/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[var(--color-champagne)] hover:underline"
+          >
+            Learn more
+          </a>
+        </p>
       </div>
-    </header>
+    </main>
   );
+
+  return showHeader ? <Layout>{mainContent}</Layout> : mainContent;
 }
 
 interface DimensionCardProps {

--- a/frontend/components/MFQAssessment.tsx
+++ b/frontend/components/MFQAssessment.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
+import { Layout } from './Layout';
 import { items, shuffleItems, type Item, citation } from '../data/mfq-items';
 import {
   type Response,
@@ -162,8 +163,7 @@ export default function MFQAssessment() {
   // Render intro phase
   if (phase === 'intro') {
     return (
-      <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-        <Header />
+      <Layout>
         <main className="mx-auto max-w-2xl px-6 py-16">
           <div className="card-premium rounded-lg p-10">
             <div className="text-center mb-8">
@@ -235,15 +235,14 @@ export default function MFQAssessment() {
             </div>
           </div>
         </main>
-      </div>
+      </Layout>
     );
   }
 
   // Render completion phase
   if (phase === 'complete') {
     return (
-      <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-        <Header />
+      <Layout>
         <main className="mx-auto max-w-2xl px-6 py-16">
           <div className="card-premium rounded-lg p-10 text-center">
             <div className="w-16 h-16 mx-auto mb-6 rounded-full border-2 border-[var(--color-champagne)] flex items-center justify-center">
@@ -283,7 +282,7 @@ export default function MFQAssessment() {
             </button>
           </div>
         </main>
-      </div>
+      </Layout>
     );
   }
 
@@ -394,20 +393,5 @@ export default function MFQAssessment() {
         </div>
       </footer>
     </div>
-  );
-}
-
-function Header() {
-  return (
-    <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
-      <div className="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
-        <Link
-          to="/"
-          className="font-display text-2xl font-semibold tracking-wide text-gold-gradient"
-        >
-          Mesearch
-        </Link>
-      </div>
-    </header>
   );
 }

--- a/frontend/components/MFQResults.tsx
+++ b/frontend/components/MFQResults.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import { Layout } from './Layout';
 import {
   type MFQResults as Results,
   type FoundationScore,
@@ -34,37 +35,34 @@ export default function MFQResults({ initialResults, showHeader = true, showActi
   }, [initialResults]);
 
   if (!results) {
-    return (
-      <div className={showHeader ? "min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300" : ""}>
-        {showHeader && <Header />}
-        <main className="mx-auto max-w-2xl px-6 py-16 text-center">
-          <div className="card-premium rounded-lg p-10">
-            <h2 className="font-display text-2xl font-medium text-[var(--color-text-primary)] mb-4">
-              No Results Found
-            </h2>
-            <p className="text-[var(--color-text-secondary)] mb-8">
-              You haven&apos;t completed the Moral Foundations Questionnaire yet.
-            </p>
-            <button
-              onClick={() => navigate('/test/mfq')}
-              className="btn-gold px-8 py-3 rounded text-sm tracking-widest uppercase"
-            >
-              Take the Test
-            </button>
-          </div>
-        </main>
-      </div>
+    const content = (
+      <main className="mx-auto max-w-2xl px-6 py-16 text-center">
+        <div className="card-premium rounded-lg p-10">
+          <h2 className="font-display text-2xl font-medium text-[var(--color-text-primary)] mb-4">
+            No Results Found
+          </h2>
+          <p className="text-[var(--color-text-secondary)] mb-8">
+            You haven&apos;t completed the Moral Foundations Questionnaire yet.
+          </p>
+          <button
+            onClick={() => navigate('/test/mfq')}
+            className="btn-gold px-8 py-3 rounded text-sm tracking-widest uppercase"
+          >
+            Take the Test
+          </button>
+        </div>
+      </main>
     );
+
+    return showHeader ? <Layout>{content}</Layout> : content;
   }
 
   const foundationScores = results.foundations;
 
-  return (
-    <div className={showHeader ? "min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300" : ""}>
-      {showHeader && <Header />}
-      <main className="mx-auto max-w-4xl px-6 py-12">
-        {/* Title */}
-        <div className="text-center mb-12">
+  const mainContent = (
+    <main className="mx-auto max-w-4xl px-6 py-12">
+      {/* Title */}
+      <div className="text-center mb-12">
           <p className="text-[var(--color-champagne)] text-xs tracking-[0.3em] uppercase mb-4">
             Your Results
           </p>
@@ -130,40 +128,26 @@ export default function MFQResults({ initialResults, showHeader = true, showActi
           </div>
         )}
 
-        {/* Citation and Disclaimer */}
-        <div className="mt-12 text-center space-y-4">
-          <div className="bg-[var(--color-bg-secondary)] rounded-lg p-6">
-            <h4 className="text-[var(--color-text-secondary)] text-xs uppercase tracking-wider mb-2">
-              Citation
-            </h4>
-            <p className="text-[var(--color-text-muted)] text-xs leading-relaxed">
-              {citation}
-            </p>
-          </div>
-          <p className="text-[var(--color-text-muted)] text-xs leading-relaxed max-w-2xl mx-auto">
-            This assessment provides a snapshot of your moral intuitions based on self-reported responses.
-            Results should be used for self-reflection and personal understanding, not as clinical diagnoses.
-            Moral foundations can be influenced by context and may change over time.
+      {/* Citation and Disclaimer */}
+      <div className="mt-12 text-center space-y-4">
+        <div className="bg-[var(--color-bg-secondary)] rounded-lg p-6">
+          <h4 className="text-[var(--color-text-secondary)] text-xs uppercase tracking-wider mb-2">
+            Citation
+          </h4>
+          <p className="text-[var(--color-text-muted)] text-xs leading-relaxed">
+            {citation}
           </p>
         </div>
-      </main>
-    </div>
-  );
-}
-
-function Header() {
-  return (
-    <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
-      <div className="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
-        <Link
-          to="/"
-          className="font-display text-2xl font-semibold tracking-wide text-gold-gradient"
-        >
-          Mesearch
-        </Link>
+        <p className="text-[var(--color-text-muted)] text-xs leading-relaxed max-w-2xl mx-auto">
+          This assessment provides a snapshot of your moral intuitions based on self-reported responses.
+          Results should be used for self-reflection and personal understanding, not as clinical diagnoses.
+          Moral foundations can be influenced by context and may change over time.
+        </p>
       </div>
-    </header>
+    </main>
   );
+
+  return showHeader ? <Layout>{mainContent}</Layout> : mainContent;
 }
 
 interface RadarChartProps {

--- a/frontend/components/MiniTestAssessment.tsx
+++ b/frontend/components/MiniTestAssessment.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { Layout } from './Layout';
 import { miniTestItems, miniTestDimensionColors, type MiniTestItem } from '../data/mini-test-items';
 import { useAuth } from '../contexts/AuthContext';
 
@@ -98,16 +99,7 @@ export default function MiniTestAssessment() {
   };
 
   return (
-    <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-      {/* Header */}
-      <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
-        <div className="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
-          <Link to="/" className="font-display text-2xl font-semibold tracking-wide text-gold-gradient">
-            Mesearch
-          </Link>
-        </div>
-      </header>
-
+    <Layout>
       <main className="mx-auto max-w-3xl px-6 py-12">
         {phase === 'intro' && (
           <div className="text-center">
@@ -291,6 +283,6 @@ export default function MiniTestAssessment() {
           </div>
         )}
       </main>
-    </div>
+    </Layout>
   );
 }

--- a/frontend/components/RMETAssessment.tsx
+++ b/frontend/components/RMETAssessment.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
+import { Layout } from './Layout';
 import {
   scoredItems,
   practiceItem,
@@ -198,8 +199,7 @@ export default function RMETAssessment() {
   // Render intro phase
   if (phase === 'intro') {
     return (
-      <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-        <Header />
+      <Layout>
         <main className="mx-auto max-w-2xl px-6 py-16">
           <div className="card-premium rounded-lg p-10">
             <div className="text-center mb-8">
@@ -297,15 +297,14 @@ export default function RMETAssessment() {
             </div>
           </div>
         </main>
-      </div>
+      </Layout>
     );
   }
 
   // Render completion phase
   if (phase === 'complete') {
     return (
-      <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-        <Header />
+      <Layout>
         <main className="mx-auto max-w-2xl px-6 py-16">
           <div className="card-premium rounded-lg p-10 text-center">
             <div className="w-16 h-16 mx-auto mb-6 rounded-full border-2 border-[var(--color-champagne)] flex items-center justify-center">
@@ -354,7 +353,7 @@ export default function RMETAssessment() {
             </button>
           </div>
         </main>
-      </div>
+      </Layout>
     );
   }
 
@@ -636,20 +635,5 @@ function EyeImage({ item }: { item: RMETItem }) {
         data-testid="rmet-image"
       />
     </div>
-  );
-}
-
-function Header() {
-  return (
-    <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
-      <div className="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
-        <Link
-          to="/"
-          className="font-display text-2xl font-semibold tracking-wide text-gold-gradient"
-        >
-          Mesearch
-        </Link>
-      </div>
-    </header>
   );
 }

--- a/frontend/components/RMETResults.tsx
+++ b/frontend/components/RMETResults.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import { Layout } from './Layout';
 import {
   type RMETResults as Results,
   deserializeResults,
@@ -31,37 +32,34 @@ export default function RMETResults({ initialResults, showHeader = true, showAct
   }, [initialResults]);
 
   if (!results) {
-    return (
-      <div className={showHeader ? "min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300" : ""}>
-        {showHeader && <Header />}
-        <main className="mx-auto max-w-2xl px-6 py-16 text-center">
-          <div className="card-premium rounded-lg p-10">
-            <h2 className="font-display text-2xl font-medium text-[var(--color-text-primary)] mb-4">
-              No Results Found
-            </h2>
-            <p className="text-[var(--color-text-secondary)] mb-8">
-              You haven&apos;t completed the RMET assessment yet.
-            </p>
-            <button
-              onClick={() => navigate('/test/rmet')}
-              className="btn-gold px-8 py-3 rounded text-sm tracking-widest uppercase"
-            >
-              Take the Test
-            </button>
-          </div>
-        </main>
-      </div>
+    const content = (
+      <main className="mx-auto max-w-2xl px-6 py-16 text-center">
+        <div className="card-premium rounded-lg p-10">
+          <h2 className="font-display text-2xl font-medium text-[var(--color-text-primary)] mb-4">
+            No Results Found
+          </h2>
+          <p className="text-[var(--color-text-secondary)] mb-8">
+            You haven&apos;t completed the RMET assessment yet.
+          </p>
+          <button
+            onClick={() => navigate('/test/rmet')}
+            className="btn-gold px-8 py-3 rounded text-sm tracking-widest uppercase"
+          >
+            Take the Test
+          </button>
+        </div>
+      </main>
     );
+
+    return showHeader ? <Layout>{content}</Layout> : content;
   }
 
   const scoreLevel = getScoreLevel(results.totalCorrect);
 
-  return (
-    <div className={showHeader ? "min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300" : ""}>
-      {showHeader && <Header />}
-      <main className="mx-auto max-w-4xl px-6 py-12">
-        {/* Title */}
-        <div className="text-center mb-12">
+  const mainContent = (
+    <main className="mx-auto max-w-4xl px-6 py-12">
+      {/* Title */}
+      <div className="text-center mb-12">
           <p className="text-[var(--color-champagne)] text-xs tracking-[0.3em] uppercase mb-4">
             Your Results
           </p>
@@ -265,33 +263,19 @@ export default function RMETResults({ initialResults, showHeader = true, showAct
           </div>
         )}
 
-        {/* Disclaimer */}
-        <div className="mt-12 text-center">
-          <p className="text-[var(--color-text-muted)] text-xs leading-relaxed max-w-2xl mx-auto">
-            This assessment provides insight into social cognition abilities but
-            should not be used for clinical diagnosis. Many factors can influence
-            test performance. Consult a qualified professional for clinical
-            evaluation.
-          </p>
-        </div>
-      </main>
-    </div>
-  );
-}
-
-function Header() {
-  return (
-    <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
-      <div className="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
-        <Link
-          to="/"
-          className="font-display text-2xl font-semibold tracking-wide text-gold-gradient"
-        >
-          Mesearch
-        </Link>
+      {/* Disclaimer */}
+      <div className="mt-12 text-center">
+        <p className="text-[var(--color-text-muted)] text-xs leading-relaxed max-w-2xl mx-auto">
+          This assessment provides insight into social cognition abilities but
+          should not be used for clinical diagnosis. Many factors can influence
+          test performance. Consult a qualified professional for clinical
+          evaluation.
+        </p>
       </div>
-    </header>
+    </main>
   );
+
+  return showHeader ? <Layout>{mainContent}</Layout> : mainContent;
 }
 
 interface ScoreCircleProps {

--- a/frontend/components/SD3Assessment.tsx
+++ b/frontend/components/SD3Assessment.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
+import { Layout } from './Layout';
 import { items, shuffleItems, type Item } from '../data/sd3-items';
 import {
   type Response,
@@ -147,8 +148,7 @@ export default function SD3Assessment() {
   // Render intro phase
   if (phase === 'intro') {
     return (
-      <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-        <Header />
+      <Layout>
         <main className="mx-auto max-w-2xl px-6 py-16">
           <div className="card-premium rounded-lg p-10">
             <div className="text-center mb-8">
@@ -235,15 +235,14 @@ export default function SD3Assessment() {
             </div>
           </div>
         </main>
-      </div>
+      </Layout>
     );
   }
 
   // Render completion phase
   if (phase === 'complete') {
     return (
-      <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-        <Header />
+      <Layout>
         <main className="mx-auto max-w-2xl px-6 py-16">
           <div className="card-premium rounded-lg p-10 text-center">
             <div className="w-16 h-16 mx-auto mb-6 rounded-full border-2 border-[var(--color-champagne)] flex items-center justify-center">
@@ -279,7 +278,7 @@ export default function SD3Assessment() {
             </button>
           </div>
         </main>
-      </div>
+      </Layout>
     );
   }
 
@@ -374,20 +373,5 @@ export default function SD3Assessment() {
         </div>
       </footer>
     </div>
-  );
-}
-
-function Header() {
-  return (
-    <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
-      <div className="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
-        <Link
-          to="/"
-          className="font-display text-2xl font-semibold tracking-wide text-gold-gradient"
-        >
-          Mesearch
-        </Link>
-      </div>
-    </header>
   );
 }

--- a/frontend/components/SD3Results.tsx
+++ b/frontend/components/SD3Results.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import { Layout } from './Layout';
 import {
   type SD3Results as Results,
   type TraitScore,
@@ -34,37 +35,34 @@ export default function SD3Results({ initialResults, showHeader = true, showActi
   }, [initialResults]);
 
   if (!results) {
-    return (
-      <div className={showHeader ? "min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300" : ""}>
-        {showHeader && <Header />}
-        <main className="mx-auto max-w-2xl px-6 py-16 text-center">
-          <div className="card-premium rounded-lg p-10">
-            <h2 className="font-display text-2xl font-medium text-[var(--color-text-primary)] mb-4">
-              No Results Found
-            </h2>
-            <p className="text-[var(--color-text-secondary)] mb-8">
-              You haven&apos;t completed the Short Dark Triad assessment yet.
-            </p>
-            <button
-              onClick={() => navigate('/test/sd3')}
-              className="btn-gold px-8 py-3 rounded text-sm tracking-widest uppercase"
-            >
-              Take the Test
-            </button>
-          </div>
-        </main>
-      </div>
+    const content = (
+      <main className="mx-auto max-w-2xl px-6 py-16 text-center">
+        <div className="card-premium rounded-lg p-10">
+          <h2 className="font-display text-2xl font-medium text-[var(--color-text-primary)] mb-4">
+            No Results Found
+          </h2>
+          <p className="text-[var(--color-text-secondary)] mb-8">
+            You haven&apos;t completed the Short Dark Triad assessment yet.
+          </p>
+          <button
+            onClick={() => navigate('/test/sd3')}
+            className="btn-gold px-8 py-3 rounded text-sm tracking-widest uppercase"
+          >
+            Take the Test
+          </button>
+        </div>
+      </main>
     );
+
+    return showHeader ? <Layout>{content}</Layout> : content;
   }
 
   const traitScores = results.traits;
 
-  return (
-    <div className={showHeader ? "min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300" : ""}>
-      {showHeader && <Header />}
-      <main className="mx-auto max-w-4xl px-6 py-12">
-        {/* Title */}
-        <div className="text-center mb-12">
+  const mainContent = (
+    <main className="mx-auto max-w-4xl px-6 py-12">
+      {/* Title */}
+      <div className="text-center mb-12">
           <p className="text-[var(--color-champagne)] text-xs tracking-[0.3em] uppercase mb-4">
             Your Results
           </p>
@@ -159,36 +157,22 @@ export default function SD3Results({ initialResults, showHeader = true, showActi
           </div>
         )}
 
-        {/* Citation */}
-        <div className="mt-12 text-center">
-          <p className="text-[var(--color-text-muted)] text-xs leading-relaxed max-w-2xl mx-auto mb-4">
-            This assessment is based on self-reported responses and measures subclinical
-            personality traits. Results should be used for self-reflection and personal insight,
-            not as clinical diagnoses or labels.
-          </p>
-          <p className="text-[var(--color-text-muted)] text-xs italic">
-            Citation: Jones, D.N., & Paulhus, D.L. (2014). Introducing the Short Dark Triad (SD3):
-            A Brief Measure of Dark Personality Traits. <em>Assessment</em>, 21(1), 28-41.
-          </p>
-        </div>
-      </main>
-    </div>
-  );
-}
-
-function Header() {
-  return (
-    <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
-      <div className="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
-        <Link
-          to="/"
-          className="font-display text-2xl font-semibold tracking-wide text-gold-gradient"
-        >
-          Mesearch
-        </Link>
+      {/* Citation */}
+      <div className="mt-12 text-center">
+        <p className="text-[var(--color-text-muted)] text-xs leading-relaxed max-w-2xl mx-auto mb-4">
+          This assessment is based on self-reported responses and measures subclinical
+          personality traits. Results should be used for self-reflection and personal insight,
+          not as clinical diagnoses or labels.
+        </p>
+        <p className="text-[var(--color-text-muted)] text-xs italic">
+          Citation: Jones, D.N., & Paulhus, D.L. (2014). Introducing the Short Dark Triad (SD3):
+          A Brief Measure of Dark Personality Traits. <em>Assessment</em>, 21(1), 28-41.
+        </p>
       </div>
-    </header>
+    </main>
   );
+
+  return showHeader ? <Layout>{mainContent}</Layout> : mainContent;
 }
 
 interface TriangleChartProps {

--- a/frontend/components/UserMenu.tsx
+++ b/frontend/components/UserMenu.tsx
@@ -72,13 +72,6 @@ export function UserMenu() {
             </p>
           </div>
           <Link
-            to="/my-results"
-            onClick={() => setIsOpen(false)}
-            className="block px-4 py-2 text-sm text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-tertiary)] hover:text-[var(--color-text-primary)] transition-colors"
-          >
-            My Results
-          </Link>
-          <Link
             to="/settings"
             onClick={() => setIsOpen(false)}
             className="block px-4 py-2 text-sm text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-tertiary)] hover:text-[var(--color-text-primary)] transition-colors"

--- a/frontend/pages/PublicProfile.tsx
+++ b/frontend/pages/PublicProfile.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Link, useParams } from 'react-router-dom';
+import { Layout } from '../components/Layout';
 
 interface PublicUser {
   username: string;
@@ -90,23 +91,7 @@ export function PublicProfile() {
   }
 
   return (
-    <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-      <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
-        <div className="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
-          <Link to="/" className="font-display text-2xl font-semibold tracking-wide text-gold-gradient">
-            Mesearch
-          </Link>
-          <nav className="flex items-center gap-6">
-            <Link
-              to="/"
-              className="text-[var(--color-text-secondary)] hover:text-[var(--color-champagne)] transition-colors text-sm"
-            >
-              Home
-            </Link>
-          </nav>
-        </div>
-      </header>
-
+    <Layout>
       <main className="mx-auto max-w-4xl px-6 py-12">
         {error ? (
           <div className="card-premium rounded-lg p-12 text-center">
@@ -187,6 +172,6 @@ export function PublicProfile() {
           </>
         ) : null}
       </main>
-    </div>
+    </Layout>
   );
 }

--- a/frontend/pages/PublicResultDetail.tsx
+++ b/frontend/pages/PublicResultDetail.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Link, useParams, useNavigate } from 'react-router-dom';
+import { Layout } from '../components/Layout';
 import BigFiveResults from '../components/BigFiveResults';
 import { EnneagramResults } from '../components/EnneagramResults';
 import HexacoResults from '../components/HexacoResults';
@@ -227,23 +228,7 @@ export function PublicResultDetail() {
   }
 
   return (
-    <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-      <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
-        <div className="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
-          <Link to="/" className="font-display text-2xl font-semibold tracking-wide text-gold-gradient">
-            Mesearch
-          </Link>
-          <nav className="flex items-center gap-6">
-            <Link
-              to="/"
-              className="text-[var(--color-text-secondary)] hover:text-[var(--color-champagne)] transition-colors text-sm"
-            >
-              Home
-            </Link>
-          </nav>
-        </div>
-      </header>
-
+    <Layout>
       <main className="mx-auto max-w-4xl px-6 py-12">
         {error ? (
           <div className="card-premium rounded-lg p-12 text-center">
@@ -296,7 +281,7 @@ export function PublicResultDetail() {
           </>
         ) : null}
       </main>
-    </div>
+    </Layout>
   );
 }
 

--- a/frontend/pages/ResultDetail.tsx
+++ b/frontend/pages/ResultDetail.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Link, useParams, useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
-import { UserMenu } from '../components/UserMenu';
+import { Layout } from '../components/Layout';
 import BigFiveResults from '../components/BigFiveResults';
 import { EnneagramResults } from '../components/EnneagramResults';
 import HexacoResults from '../components/HexacoResults';
@@ -116,8 +116,7 @@ export function ResultDetail() {
 
   if (!user) {
     return (
-      <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-        <Header />
+      <Layout>
         <main className="mx-auto max-w-4xl px-6 py-12">
           <div className="card-premium rounded-lg p-12 text-center">
             <div className="w-16 h-16 mx-auto mb-6 rounded-full border border-[var(--color-champagne)]/30 flex items-center justify-center">
@@ -131,14 +130,13 @@ export function ResultDetail() {
             </p>
           </div>
         </main>
-      </div>
+      </Layout>
     );
   }
 
   if (error) {
     return (
-      <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-        <Header />
+      <Layout>
         <main className="mx-auto max-w-4xl px-6 py-12">
           <div className="card-premium rounded-lg p-12 text-center">
             <div className="w-16 h-16 mx-auto mb-6 rounded-full border border-red-500/30 flex items-center justify-center">
@@ -156,14 +154,13 @@ export function ResultDetail() {
             </Link>
           </div>
         </main>
-      </div>
+      </Layout>
     );
   }
 
   if (!result) {
     return (
-      <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-        <Header />
+      <Layout>
         <main className="mx-auto max-w-4xl px-6 py-12">
           <div className="card-premium rounded-lg p-12 text-center">
             <h2 className="font-display text-xl text-[var(--color-text-primary)] mb-2">Result Not Found</h2>
@@ -178,15 +175,14 @@ export function ResultDetail() {
             </Link>
           </div>
         </main>
-      </div>
+      </Layout>
     );
   }
 
   const retakeUrl = testUrls[result.test_type] || `/test/${result.test_type}`;
 
   return (
-    <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-      <Header />
+    <Layout>
       <main className="mx-auto max-w-4xl px-6 py-12">
         {/* Back link */}
         <Link
@@ -300,28 +296,7 @@ export function ResultDetail() {
           </Link>
         </div>
       </main>
-    </div>
-  );
-}
-
-function Header() {
-  return (
-    <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
-      <div className="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
-        <Link to="/" className="font-display text-2xl font-semibold tracking-wide text-gold-gradient">
-          Mesearch
-        </Link>
-        <nav className="flex items-center gap-6">
-          <Link
-            to="/my-results"
-            className="text-[var(--color-text-secondary)] hover:text-[var(--color-champagne)] transition-colors text-sm"
-          >
-            My Results
-          </Link>
-          <UserMenu />
-        </nav>
-      </div>
-    </header>
+    </Layout>
   );
 }
 

--- a/frontend/pages/ResultsHistory.tsx
+++ b/frontend/pages/ResultsHistory.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
-import { UserMenu } from '../components/UserMenu';
+import { Layout } from '../components/Layout';
 
 interface TestResult {
   id: string;
@@ -141,24 +141,7 @@ export function ResultsHistory() {
   }
 
   return (
-    <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-      <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
-        <div className="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
-          <Link to="/" className="font-display text-2xl font-semibold tracking-wide text-gold-gradient">
-            Mesearch
-          </Link>
-          <nav className="flex items-center gap-6">
-            <Link
-              to="/"
-              className="text-[var(--color-text-secondary)] hover:text-[var(--color-champagne)] transition-colors text-sm"
-            >
-              Home
-            </Link>
-            <UserMenu />
-          </nav>
-        </div>
-      </header>
-
+    <Layout>
       <main className="mx-auto max-w-4xl px-6 py-12">
         <div className="mb-8">
           <p className="text-[var(--color-champagne)] text-xs tracking-[0.3em] uppercase mb-2">Your Journey</p>
@@ -290,6 +273,6 @@ export function ResultsHistory() {
           </div>
         )}
       </main>
-    </div>
+    </Layout>
   );
 }

--- a/frontend/pages/Settings.tsx
+++ b/frontend/pages/Settings.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
-import { UserMenu } from '../components/UserMenu';
+import { Layout } from '../components/Layout';
 
 interface Profile {
   id: string;
@@ -136,24 +136,7 @@ export function Settings() {
   }
 
   return (
-    <div className="min-h-screen bg-[var(--color-bg-primary)] transition-colors duration-300">
-      <header className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)]/95 backdrop-blur-md transition-colors duration-300">
-        <div className="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
-          <Link to="/" className="font-display text-2xl font-semibold tracking-wide text-gold-gradient">
-            Mesearch
-          </Link>
-          <nav className="flex items-center gap-6">
-            <Link
-              to="/"
-              className="text-[var(--color-text-secondary)] hover:text-[var(--color-champagne)] transition-colors text-sm"
-            >
-              Home
-            </Link>
-            <UserMenu />
-          </nav>
-        </div>
-      </header>
-
+    <Layout>
       <main className="mx-auto max-w-2xl px-6 py-12">
         <div className="mb-8">
           <p className="text-[var(--color-champagne)] text-xs tracking-[0.3em] uppercase mb-2">Account</p>
@@ -314,6 +297,6 @@ export function Settings() {
           </form>
         )}
       </main>
-    </div>
+    </Layout>
   );
 }

--- a/frontend/pages/TestsPage.tsx
+++ b/frontend/pages/TestsPage.tsx
@@ -1,0 +1,234 @@
+import { Link } from 'react-router-dom';
+import { Layout } from '../components/Layout';
+import { useFeatureFlags } from '../contexts/FeatureFlagsContext';
+
+function RatingDots({ value, max = 5 }: { value: number; max?: number }) {
+  return (
+    <div className="flex gap-1">
+      {Array.from({ length: max }).map((_, i) => (
+        <div
+          key={i}
+          className={`w-1.5 h-1.5 rounded-full ${
+            i < value
+              ? 'bg-[var(--color-champagne)]'
+              : 'bg-[var(--color-border)]'
+          }`}
+        />
+      ))}
+    </div>
+  );
+}
+
+function TestCard({
+  title,
+  subtitle,
+  slug,
+  keywords,
+  description,
+  time,
+  seriousness,
+  fun,
+  link,
+}: {
+  title: string;
+  subtitle: string;
+  slug: string;
+  keywords: string[];
+  description: string;
+  time: string;
+  seriousness: number;
+  fun: number;
+  link?: string;
+}) {
+  const href = link || `/test/${slug}`;
+  return (
+    <div className="card-premium rounded-lg p-8 group">
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex gap-6">
+          <div className="flex items-center gap-2">
+            <span className="text-[var(--color-text-muted)] text-[10px] tracking-wide uppercase">Seriousness</span>
+            <RatingDots value={seriousness} />
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-[var(--color-text-muted)] text-[10px] tracking-wide uppercase">Fun</span>
+            <RatingDots value={fun} />
+          </div>
+        </div>
+        <span className="text-[var(--color-text-muted)] text-xs tracking-wide">{time}</span>
+      </div>
+      <h4 className="font-display text-2xl font-medium text-[var(--color-text-primary)] mb-1 transition-colors duration-300">{title}</h4>
+      <p className="text-[var(--color-champagne)]/70 text-sm mb-4 tracking-wide">{subtitle}</p>
+      <p className="text-[var(--color-text-muted)] text-xs mb-3 tracking-wide">
+        {keywords.join(' · ')}
+      </p>
+      <p className="text-[var(--color-text-secondary)] text-sm mb-8 leading-relaxed transition-colors duration-300">{description}</p>
+      <Link
+        to={href}
+        className="btn-ghost block w-full py-3 rounded text-center text-xs tracking-widest uppercase"
+      >
+        Begin Assessment
+      </Link>
+    </div>
+  );
+}
+
+export function TestsPage() {
+  const { flags } = useFeatureFlags();
+
+  return (
+    <Layout>
+      <main className="mx-auto max-w-6xl px-6 py-12">
+        <div className="text-center mb-16">
+          <p className="text-[var(--color-champagne)] text-xs tracking-[0.3em] uppercase mb-4">Assessments</p>
+          <h1 className="font-display text-4xl md:text-5xl font-medium text-[var(--color-text-primary)] transition-colors duration-300 mb-4">
+            Explore Tests
+          </h1>
+          <p className="text-[var(--color-text-secondary)] max-w-2xl mx-auto leading-relaxed">
+            Each test is rated on two dimensions: Seriousness reflects the depth of research
+            supporting its validity, while Fun captures how engaging the experience is.
+          </p>
+        </div>
+
+        {/* Primary Tests - High scientific validity */}
+        <div className="grid md:grid-cols-3 gap-8">
+          <TestCard
+            title="Big Five"
+            subtitle="IPIP-NEO"
+            slug="big-five"
+            keywords={['Traits', 'Behavior', 'Stability']}
+            description="The gold standard in personality psychology. Measures Openness, Conscientiousness, Extraversion, Agreeableness, and Neuroticism."
+            time="15 min"
+            seriousness={5}
+            fun={3}
+          />
+          <TestCard
+            title="HEXACO"
+            subtitle="Six Dimensions"
+            slug="hexaco"
+            link="/hexaco"
+            keywords={['Ethics', 'Honesty', 'Integrity']}
+            description="Six-factor model including Honesty-Humility. Predicts ethical behavior and workplace conduct with precision."
+            time="12 min"
+            seriousness={5}
+            fun={2}
+          />
+          <TestCard
+            title="Attachment Style"
+            subtitle="ECR-RS"
+            slug="ecr"
+            keywords={['Relationships', 'Anxiety', 'Avoidance']}
+            description="Understand your attachment patterns in close relationships. Measures anxiety and avoidance on continuous dimensions."
+            time="5 min"
+            seriousness={5}
+            fun={4}
+          />
+        </div>
+
+        {/* Second Row */}
+        <div className="grid md:grid-cols-3 gap-8 mt-8">
+          <TestCard
+            title="Moral Foundations"
+            subtitle="MFQ-30"
+            slug="mfq"
+            keywords={['Ethics', 'Values', 'Politics']}
+            description="Discover your moral intuitions across five foundations: Care, Fairness, Loyalty, Authority, and Purity. Based on Jonathan Haidt's research."
+            time="10 min"
+            seriousness={4}
+            fun={4}
+          />
+          <TestCard
+            title="Dark Triad"
+            subtitle="SD3"
+            slug="sd3"
+            keywords={['Strategy', 'Confidence', 'Boldness']}
+            description="Measures subclinical Machiavellianism, Narcissism, and Psychopathy. High engagement due to 'forbidden' appeal."
+            time="5 min"
+            seriousness={4}
+            fun={5}
+          />
+          <TestCard
+            title="CRT"
+            subtitle="Cognitive Reflection"
+            slug="crt"
+            keywords={['Reasoning', 'Reflection', 'Intuition']}
+            description="Test your ability to override intuitive wrong answers through deliberate reflection. The famous 'bat and ball' problem and more."
+            time="5 min"
+            seriousness={4}
+            fun={5}
+          />
+        </div>
+
+        {/* Third Row */}
+        <div className="grid md:grid-cols-3 gap-8 mt-8">
+          <TestCard
+            title="RMET"
+            subtitle="Eyes Test"
+            slug="rmet"
+            keywords={['Social Cognition', 'Empathy', 'Theory of Mind']}
+            description="Measure your ability to recognize emotions and mental states from eye expressions. Research-backed assessment of social cognition."
+            time="10 min"
+            seriousness={4}
+            fun={4}
+          />
+          <TestCard
+            title="Myers-Briggs"
+            subtitle="OEJTS"
+            slug="mbti"
+            keywords={['Types', 'Cognitive', 'Popular']}
+            description="The world's most popular personality test. Discover your type across four dichotomies: E/I, S/N, T/F, J/P."
+            time="10 min"
+            seriousness={2}
+            fun={5}
+          />
+          <TestCard
+            title="Enneagram"
+            subtitle="Nine Types"
+            slug="enneagram"
+            keywords={['Motivations', 'Growth', 'Archetypes']}
+            description="Explore your core motivations through nine distinct personality archetypes. Renowned for personal growth insights."
+            time="10 min"
+            seriousness={2}
+            fun={5}
+          />
+        </div>
+
+        {/* Fourth Row */}
+        <div className="grid md:grid-cols-3 gap-8 mt-8">
+          <TestCard
+            title="Communication Styles"
+            subtitle="Five Styles"
+            slug="communication-styles"
+            keywords={['Relationships', 'Appreciation', 'Connection']}
+            description="Discover how you prefer to give and receive appreciation. Learn your primary style for deeper connections."
+            time="5 min"
+            seriousness={2}
+            fun={5}
+          />
+        </div>
+
+        {/* Mini-Test - Admin/Test Users Only */}
+        {flags.mini_test && (
+          <div className="mt-12" data-testid="mini-test-section">
+            <div className="text-center mb-6">
+              <span className="inline-block px-3 py-1 rounded-full bg-amber-500/20 border border-amber-500/30 text-amber-400 text-xs tracking-wide uppercase">
+                Debug / Testing Only
+              </span>
+            </div>
+            <div className="max-w-md mx-auto">
+              <TestCard
+                title="Mini-Test"
+                subtitle="5 Questions"
+                slug="mini-test"
+                keywords={['Debug', 'Testing', 'Quick']}
+                description="A 5-question sampler for debugging and automated testing. One question from each Big Five dimension."
+                time="1 min"
+                seriousness={1}
+                fun={1}
+              />
+            </div>
+          </div>
+        )}
+      </main>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- Creates a shared Layout component with consistent navigation header
- All pages now have: Tests, Results, Sign In (or user dropdown if logged in)
- User dropdown shows Settings and Sign Out only (Results moved to main nav)
- Removed "About" from navigation
- Reduced codebase by ~400 lines by eliminating duplicate headers

## Changes
- **New:** `frontend/components/Layout.tsx` - shared layout with navigation
- **Updated:** All page and component files to use Layout
- **Updated:** UserMenu to remove "My Results" (now in main nav as "Results")
- **Updated:** E2E tests for new navigation structure

## Screenshots
| Before (Settings) | After (Settings) |
|-------------------|------------------|
| Only had "Home" link | Same nav as all pages |

## Test plan
- [x] Build passes (`npm run build:frontend`)
- [x] TypeScript checks pass (`npx tsc --noEmit`)
- [x] Homepage shows Tests, Results, Sign In in nav
- [x] Settings page shows same nav (was different before)
- [x] All test/assessment pages have consistent nav
- [ ] E2E tests pass (some auth tests flaky due to DB setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)