### PR TITLE
Redesign Tests page with category navigation (#68)

### DIFF
--- a/e2e/crt.spec.ts
+++ b/e2e/crt.spec.ts
@@ -8,16 +8,16 @@ test.describe('Cognitive Reflection Test (CRT)', () => {
   });
 
   test.describe('Navigation and Intro', () => {
-    test('CRT card is visible on tests page', async ({ page }) => {
-      await page.goto('/tests');
+    test('CRT card is visible on cognitive category page', async ({ page }) => {
+      await page.goto('/tests/cognitive');
 
-      // Should see the CRT test card
+      // Should see the CRT test card in the Cognitive category
       await expect(page.getByRole('heading', { name: 'CRT' })).toBeVisible();
       await expect(page.getByText('Cognitive Reflection')).toBeVisible();
     });
 
-    test('can navigate to CRT from tests page', async ({ page }) => {
-      await page.goto('/tests');
+    test('can navigate to CRT from category page', async ({ page }) => {
+      await page.goto('/tests/cognitive');
 
       // Find the CRT card and click the begin button
       const crtCard = page.locator('.card-premium', { has: page.getByRole('heading', { name: 'CRT' }) });

--- a/e2e/crt.spec.ts
+++ b/e2e/crt.spec.ts
@@ -13,7 +13,7 @@ test.describe('Cognitive Reflection Test (CRT)', () => {
 
       // Should see the CRT test card in the Cognitive category
       await expect(page.getByRole('heading', { name: 'CRT' })).toBeVisible();
-      await expect(page.getByText('Cognitive Reflection')).toBeVisible();
+      await expect(page.getByText('Reasoning')).toBeVisible();
     });
 
     test('can navigate to CRT from category page', async ({ page }) => {

--- a/e2e/crt.spec.ts
+++ b/e2e/crt.spec.ts
@@ -19,9 +19,9 @@ test.describe('Cognitive Reflection Test (CRT)', () => {
     test('can navigate to CRT from category page', async ({ page }) => {
       await page.goto('/tests/cognitive');
 
-      // Find the CRT card and click the begin button
-      const crtCard = page.locator('.card-premium', { has: page.getByRole('heading', { name: 'CRT' }) });
-      await crtCard.getByRole('link', { name: 'Begin Assessment' }).click();
+      // Click on the CRT card (entire card is clickable)
+      const crtCard = page.locator('a.card-premium', { has: page.getByRole('heading', { name: 'CRT' }) });
+      await crtCard.click();
 
       // Should see the CRT intro page
       await expect(page.getByRole('heading', { name: 'Cognitive Reflection Test' })).toBeVisible();

--- a/e2e/ecr.spec.ts
+++ b/e2e/ecr.spec.ts
@@ -140,8 +140,8 @@ test.describe('ECR Attachment Style Assessment', () => {
     await expect(page.getByTestId('ecr-progress')).toContainText('1 of 9');
   });
 
-  test('ECR card is visible on tests page', async ({ page }) => {
-    await page.goto('/tests');
+  test('ECR card is visible on relationships category page', async ({ page }) => {
+    await page.goto('/tests/relationships');
 
     // Verify ECR test card is present
     await expect(page.getByText('Attachment Style')).toBeVisible();

--- a/e2e/ecr.spec.ts
+++ b/e2e/ecr.spec.ts
@@ -145,7 +145,6 @@ test.describe('ECR Attachment Style Assessment', () => {
 
     // Verify ECR test card is present
     await expect(page.getByText('Attachment Style')).toBeVisible();
-    await expect(page.getByText('ECR-RS')).toBeVisible();
     await expect(page.getByText(/anxiety and avoidance/i)).toBeVisible();
   });
 

--- a/e2e/iat.spec.ts
+++ b/e2e/iat.spec.ts
@@ -7,8 +7,8 @@ test.describe('Implicit Association Test (IAT)', () => {
 
       // IAT card should be visible on IAT category page
       await expect(page.getByRole('heading', { name: 'Flowers-Insects IAT' })).toBeVisible();
-      // Check for the subtitle within the test card
-      await expect(page.getByText('Implicit Association Test', { exact: true })).toBeVisible();
+      // Check for keywords within the test card
+      await expect(page.getByText('Reaction Time')).toBeVisible();
     });
 
     test('can navigate to IAT directly via URL', async ({ page }) => {

--- a/e2e/iat.spec.ts
+++ b/e2e/iat.spec.ts
@@ -2,12 +2,13 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Implicit Association Test (IAT)', () => {
   test.describe('IAT Accessibility', () => {
-    test('IAT is visible on tests page', async ({ page }) => {
-      await page.goto('/tests');
+    test('IAT is visible on iat category page', async ({ page }) => {
+      await page.goto('/tests/iat');
 
-      // IAT card should be visible on tests page
-      await expect(page.getByRole('heading', { name: 'IAT' })).toBeVisible();
-      await expect(page.getByText('Implicit Association Test')).toBeVisible();
+      // IAT card should be visible on IAT category page
+      await expect(page.getByRole('heading', { name: 'Flowers-Insects IAT' })).toBeVisible();
+      // Check for the subtitle within the test card
+      await expect(page.getByText('Implicit Association Test', { exact: true })).toBeVisible();
     });
 
     test('can navigate to IAT directly via URL', async ({ page }) => {

--- a/e2e/iat.spec.ts
+++ b/e2e/iat.spec.ts
@@ -7,8 +7,8 @@ test.describe('Implicit Association Test (IAT)', () => {
 
       // IAT card should be visible on IAT category page
       await expect(page.getByRole('heading', { name: 'Flowers-Insects IAT' })).toBeVisible();
-      // Check for keywords within the test card
-      await expect(page.getByText('Reaction Time')).toBeVisible();
+      // Check for test description
+      await expect(page.getByText('Measure automatic associations between flowers/insects')).toBeVisible();
     });
 
     test('can navigate to IAT directly via URL', async ({ page }) => {

--- a/e2e/love-languages.spec.ts
+++ b/e2e/love-languages.spec.ts
@@ -7,7 +7,6 @@ test.describe('Communication Styles Assessment', () => {
 
       // Should see the Communication Styles test card
       await expect(page.getByRole('heading', { name: 'Communication Styles' })).toBeVisible();
-      await expect(page.getByText('Five Styles')).toBeVisible();
       await expect(page.getByText('Discover how you prefer to give and receive appreciation')).toBeVisible();
     });
   });

--- a/e2e/love-languages.spec.ts
+++ b/e2e/love-languages.spec.ts
@@ -2,8 +2,8 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Communication Styles Assessment', () => {
   test.describe('Tests Page', () => {
-    test('communication styles card is visible on tests page', async ({ page }) => {
-      await page.goto('/tests');
+    test('communication styles card is visible on relationships category page', async ({ page }) => {
+      await page.goto('/tests/relationships');
 
       // Should see the Communication Styles test card
       await expect(page.getByRole('heading', { name: 'Communication Styles' })).toBeVisible();

--- a/e2e/mbti.spec.ts
+++ b/e2e/mbti.spec.ts
@@ -18,9 +18,9 @@ test.describe('Myers-Briggs Style Test (OEJTS)', () => {
   test('can navigate to MBTI assessment and see intro', async ({ page }) => {
     await page.goto('/tests/personality');
 
-    // Click on the MBTI test card's "Begin Assessment" link
-    const mbtiCard = page.locator('.card-premium', { hasText: 'Myers-Briggs' });
-    await mbtiCard.getByRole('link', { name: 'Begin Assessment' }).click();
+    // Click on the MBTI test card (entire card is clickable)
+    const mbtiCard = page.locator('a.card-premium', { hasText: 'Myers-Briggs' });
+    await mbtiCard.click();
 
     // Should be on the MBTI intro page
     await expect(page).toHaveURL('/test/mbti');

--- a/e2e/mbti.spec.ts
+++ b/e2e/mbti.spec.ts
@@ -12,7 +12,7 @@ test.describe('Myers-Briggs Style Test (OEJTS)', () => {
 
     // MBTI card should be visible
     await expect(page.getByRole('heading', { name: 'Myers-Briggs' })).toBeVisible();
-    await expect(page.getByText('Types')).toBeVisible();
+    await expect(page.getByText("The world's most popular personality test")).toBeVisible();
   });
 
   test('can navigate to MBTI assessment and see intro', async ({ page }) => {

--- a/e2e/mbti.spec.ts
+++ b/e2e/mbti.spec.ts
@@ -12,7 +12,7 @@ test.describe('Myers-Briggs Style Test (OEJTS)', () => {
 
     // MBTI card should be visible
     await expect(page.getByRole('heading', { name: 'Myers-Briggs' })).toBeVisible();
-    await expect(page.getByText('OEJTS')).toBeVisible();
+    await expect(page.getByText('Types')).toBeVisible();
   });
 
   test('can navigate to MBTI assessment and see intro', async ({ page }) => {

--- a/e2e/mbti.spec.ts
+++ b/e2e/mbti.spec.ts
@@ -7,8 +7,8 @@ test.describe('Myers-Briggs Style Test (OEJTS)', () => {
     await page.evaluate(() => localStorage.clear());
   });
 
-  test('MBTI test card is visible on tests page', async ({ page }) => {
-    await page.goto('/tests');
+  test('MBTI test card is visible on personality category page', async ({ page }) => {
+    await page.goto('/tests/personality');
 
     // MBTI card should be visible
     await expect(page.getByRole('heading', { name: 'Myers-Briggs' })).toBeVisible();
@@ -16,7 +16,7 @@ test.describe('Myers-Briggs Style Test (OEJTS)', () => {
   });
 
   test('can navigate to MBTI assessment and see intro', async ({ page }) => {
-    await page.goto('/tests');
+    await page.goto('/tests/personality');
 
     // Click on the MBTI test card's "Begin Assessment" link
     const mbtiCard = page.locator('.card-premium', { hasText: 'Myers-Briggs' });

--- a/e2e/mfq.spec.ts
+++ b/e2e/mfq.spec.ts
@@ -96,8 +96,8 @@ test.describe('Moral Foundations Questionnaire Assessment', () => {
     await expect(page.getByText('6 of 30')).toBeVisible();
   });
 
-  test('shows MFQ card on tests page', async ({ page }) => {
-    await page.goto('/tests');
+  test('shows MFQ card on values category page', async ({ page }) => {
+    await page.goto('/tests/values');
 
     // Verify the MFQ test card is visible
     await expect(page.getByText('Moral Foundations')).toBeVisible();

--- a/e2e/mfq.spec.ts
+++ b/e2e/mfq.spec.ts
@@ -101,8 +101,6 @@ test.describe('Moral Foundations Questionnaire Assessment', () => {
 
     // Verify the MFQ test card is visible
     await expect(page.getByText('Moral Foundations')).toBeVisible();
-    await expect(page.getByText('MFQ-30')).toBeVisible();
-    // Use more specific selector since multiple cards have "Ethics" keyword
     await expect(page.getByText('Ethics · Values · Politics')).toBeVisible();
   });
 

--- a/e2e/rmet.spec.ts
+++ b/e2e/rmet.spec.ts
@@ -159,8 +159,8 @@ test.describe('RMET Assessment', () => {
     await expect(page.getByText('2 of 37')).toBeVisible();
   });
 
-  test('displays RMET card on tests page', async ({ page }) => {
-    await page.goto('/tests');
+  test('displays RMET card on empathy category page', async ({ page }) => {
+    await page.goto('/tests/empathy');
 
     // Should see RMET test card
     await expect(page.getByRole('heading', { name: 'RMET' })).toBeVisible();

--- a/e2e/rmet.spec.ts
+++ b/e2e/rmet.spec.ts
@@ -164,7 +164,6 @@ test.describe('RMET Assessment', () => {
 
     // Should see RMET test card
     await expect(page.getByRole('heading', { name: 'RMET' })).toBeVisible();
-    await expect(page.getByText('Eyes Test')).toBeVisible();
     await expect(page.getByText('Social Cognition', { exact: false }).first()).toBeVisible();
   });
 

--- a/e2e/sd3.spec.ts
+++ b/e2e/sd3.spec.ts
@@ -102,10 +102,9 @@ test.describe('Short Dark Triad (SD3) Assessment', () => {
   test('can navigate to SD3 from personality category page', async ({ page }) => {
     await page.goto('/tests/personality');
 
-    // Find the SD3 test card and click "Begin Assessment"
-    // The card contains "Dark Triad" heading and has a Begin Assessment link
-    const sd3Card = page.locator('.card-premium', { has: page.getByRole('heading', { name: 'Dark Triad' }) });
-    await sd3Card.getByRole('link', { name: /Begin Assessment/i }).click();
+    // Click on the SD3 test card (entire card is clickable)
+    const sd3Card = page.locator('a.card-premium', { has: page.getByRole('heading', { name: 'Dark Triad' }) });
+    await sd3Card.click();
 
     // Should be on SD3 assessment page
     await expect(page).toHaveURL('/test/sd3');

--- a/e2e/sd3.spec.ts
+++ b/e2e/sd3.spec.ts
@@ -88,8 +88,8 @@ test.describe('Short Dark Triad (SD3) Assessment', () => {
     await expect(page.getByTestId('sd3-progress')).toHaveText('6 of 27');
   });
 
-  test('SD3 test card is visible on tests page', async ({ page }) => {
-    await page.goto('/tests');
+  test('SD3 test card is visible on personality category page', async ({ page }) => {
+    await page.goto('/tests/personality');
 
     // Verify the SD3 test card is displayed - scope to the card to avoid strict mode violations
     const sd3Card = page.locator('.card-premium', { has: page.getByRole('heading', { name: 'Dark Triad' }) });
@@ -99,8 +99,8 @@ test.describe('Short Dark Triad (SD3) Assessment', () => {
     await expect(sd3Card.getByText('Machiavellianism, Narcissism, and Psychopathy')).toBeVisible();
   });
 
-  test('can navigate to SD3 from tests page', async ({ page }) => {
-    await page.goto('/tests');
+  test('can navigate to SD3 from personality category page', async ({ page }) => {
+    await page.goto('/tests/personality');
 
     // Find the SD3 test card and click "Begin Assessment"
     // The card contains "Dark Triad" heading and has a Begin Assessment link

--- a/e2e/sd3.spec.ts
+++ b/e2e/sd3.spec.ts
@@ -92,9 +92,8 @@ test.describe('Short Dark Triad (SD3) Assessment', () => {
     await page.goto('/tests/personality');
 
     // Verify the SD3 test card is displayed - scope to the card to avoid strict mode violations
-    const sd3Card = page.locator('.card-premium', { has: page.getByRole('heading', { name: 'Dark Triad' }) });
+    const sd3Card = page.locator('a.card-premium', { has: page.getByRole('heading', { name: 'Dark Triad' }) });
     await expect(sd3Card.getByRole('heading', { name: 'Dark Triad' })).toBeVisible();
-    await expect(sd3Card.getByText('SD3')).toBeVisible();
     await expect(sd3Card.getByText('5 min', { exact: true })).toBeVisible();
     await expect(sd3Card.getByText('Machiavellianism, Narcissism, and Psychopathy')).toBeVisible();
   });

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -32,6 +32,7 @@ import MBTIResults from './components/MBTIResults';
 import RMETAssessment from './components/RMETAssessment';
 import RMETResults from './components/RMETResults';
 import { TestsPage } from './pages/TestsPage';
+import { CategoryPage } from './pages/CategoryPage';
 
 function HomePage() {
   return (
@@ -393,6 +394,7 @@ export default function App() {
           <Routes>
             <Route path="/" element={<HomePage />} />
             <Route path="/tests" element={<TestsPage />} />
+            <Route path="/tests/:categoryId" element={<CategoryPage />} />
             <Route path="/my-results" element={<ResultsHistory />} />
             <Route path="/results/:id" element={<ResultDetail />} />
             <Route path="/settings" element={<Settings />} />

--- a/frontend/data/test-categories.ts
+++ b/frontend/data/test-categories.ts
@@ -1,0 +1,200 @@
+export interface TestInfo {
+  title: string;
+  subtitle: string;
+  slug: string;
+  keywords: string[];
+  description: string;
+  time: string;
+  seriousness: number;
+  fun: number;
+  link?: string;
+}
+
+export interface Category {
+  id: string;
+  title: string;
+  subtitle: string;
+  description: string;
+  icon: string;
+  tests: TestInfo[];
+}
+
+export const categories: Category[] = [
+  {
+    id: 'personality',
+    title: 'Personality',
+    subtitle: 'Trait-based assessments',
+    description: 'Explore your fundamental personality traits through scientifically validated and popular frameworks.',
+    icon: '🎭',
+    tests: [
+      {
+        title: 'Big Five',
+        subtitle: 'IPIP-NEO',
+        slug: 'big-five',
+        keywords: ['Traits', 'Behavior', 'Stability'],
+        description: 'The gold standard in personality psychology. Measures Openness, Conscientiousness, Extraversion, Agreeableness, and Neuroticism.',
+        time: '15 min',
+        seriousness: 5,
+        fun: 3,
+      },
+      {
+        title: 'HEXACO',
+        subtitle: 'Six Dimensions',
+        slug: 'hexaco',
+        link: '/hexaco',
+        keywords: ['Ethics', 'Honesty', 'Integrity'],
+        description: 'Six-factor model including Honesty-Humility. Predicts ethical behavior and workplace conduct with precision.',
+        time: '12 min',
+        seriousness: 5,
+        fun: 2,
+      },
+      {
+        title: 'Myers-Briggs',
+        subtitle: 'OEJTS',
+        slug: 'mbti',
+        keywords: ['Types', 'Cognitive', 'Popular'],
+        description: "The world's most popular personality test. Discover your type across four dichotomies: E/I, S/N, T/F, J/P.",
+        time: '10 min',
+        seriousness: 2,
+        fun: 5,
+      },
+      {
+        title: 'Enneagram',
+        subtitle: 'Nine Types',
+        slug: 'enneagram',
+        keywords: ['Motivations', 'Growth', 'Archetypes'],
+        description: 'Explore your core motivations through nine distinct personality archetypes. Renowned for personal growth insights.',
+        time: '10 min',
+        seriousness: 2,
+        fun: 5,
+      },
+      {
+        title: 'Dark Triad',
+        subtitle: 'SD3',
+        slug: 'sd3',
+        keywords: ['Strategy', 'Confidence', 'Boldness'],
+        description: "Measures subclinical Machiavellianism, Narcissism, and Psychopathy. High engagement due to 'forbidden' appeal.",
+        time: '5 min',
+        seriousness: 4,
+        fun: 5,
+      },
+    ],
+  },
+  {
+    id: 'iat',
+    title: 'Implicit Association Tests',
+    subtitle: 'Reaction-time based measures',
+    description: 'Measure automatic associations through reaction time. Educational tools for exploring implicit cognition.',
+    icon: '⚡',
+    tests: [
+      {
+        title: 'Flowers-Insects IAT',
+        subtitle: 'Implicit Association Test',
+        slug: 'iat',
+        keywords: ['Reaction Time', 'Automatic Associations', 'Self-Reflection'],
+        description: 'Measure automatic associations between flowers/insects and pleasant/unpleasant concepts. A practice IAT to learn the format.',
+        time: '5-10 min',
+        seriousness: 3,
+        fun: 4,
+      },
+    ],
+  },
+  {
+    id: 'empathy',
+    title: 'Empathy & Social Cognition',
+    subtitle: 'Understanding others',
+    description: 'Assess your ability to understand emotions, mental states, and social dynamics.',
+    icon: '👁️',
+    tests: [
+      {
+        title: 'RMET',
+        subtitle: 'Eyes Test',
+        slug: 'rmet',
+        keywords: ['Social Cognition', 'Empathy', 'Theory of Mind'],
+        description: 'Measure your ability to recognize emotions and mental states from eye expressions. Research-backed assessment of social cognition.',
+        time: '10 min',
+        seriousness: 4,
+        fun: 4,
+      },
+    ],
+  },
+  {
+    id: 'values',
+    title: 'Values & Morality',
+    subtitle: 'Ethical frameworks',
+    description: 'Discover your moral intuitions and the values that guide your ethical decision-making.',
+    icon: '⚖️',
+    tests: [
+      {
+        title: 'Moral Foundations',
+        subtitle: 'MFQ-30',
+        slug: 'mfq',
+        keywords: ['Ethics', 'Values', 'Politics'],
+        description: "Discover your moral intuitions across five foundations: Care, Fairness, Loyalty, Authority, and Purity. Based on Jonathan Haidt's research.",
+        time: '10 min',
+        seriousness: 4,
+        fun: 4,
+      },
+    ],
+  },
+  {
+    id: 'cognitive',
+    title: 'Cognitive',
+    subtitle: 'Thinking patterns',
+    description: 'Explore how you think, reason, and make decisions.',
+    icon: '🧠',
+    tests: [
+      {
+        title: 'CRT',
+        subtitle: 'Cognitive Reflection',
+        slug: 'crt',
+        keywords: ['Reasoning', 'Reflection', 'Intuition'],
+        description: "Test your ability to override intuitive wrong answers through deliberate reflection. The famous 'bat and ball' problem and more.",
+        time: '5 min',
+        seriousness: 4,
+        fun: 5,
+      },
+    ],
+  },
+  {
+    id: 'relationships',
+    title: 'Relationships',
+    subtitle: 'Connection patterns',
+    description: 'Understand how you connect with others, express appreciation, and form attachments.',
+    icon: '💕',
+    tests: [
+      {
+        title: 'Attachment Style',
+        subtitle: 'ECR-RS',
+        slug: 'ecr',
+        keywords: ['Relationships', 'Anxiety', 'Avoidance'],
+        description: 'Understand your attachment patterns in close relationships. Measures anxiety and avoidance on continuous dimensions.',
+        time: '5 min',
+        seriousness: 5,
+        fun: 4,
+      },
+      {
+        title: 'Communication Styles',
+        subtitle: 'Five Styles',
+        slug: 'communication-styles',
+        keywords: ['Relationships', 'Appreciation', 'Connection'],
+        description: 'Discover how you prefer to give and receive appreciation. Learn your primary style for deeper connections.',
+        time: '5 min',
+        seriousness: 2,
+        fun: 5,
+      },
+    ],
+  },
+];
+
+export function getCategoryById(id: string): Category | undefined {
+  return categories.find((cat) => cat.id === id);
+}
+
+export function getTestBySlug(slug: string): TestInfo | undefined {
+  for (const category of categories) {
+    const test = category.tests.find((t) => t.slug === slug);
+    if (test) return test;
+  }
+  return undefined;
+}

--- a/frontend/data/test-categories.ts
+++ b/frontend/data/test-categories.ts
@@ -15,7 +15,6 @@ export interface Category {
   title: string;
   subtitle: string;
   description: string;
-  icon: string;
   tests: TestInfo[];
 }
 
@@ -25,7 +24,6 @@ export const categories: Category[] = [
     title: 'Personality',
     subtitle: 'Trait-based assessments',
     description: 'Explore your fundamental personality traits through scientifically validated and popular frameworks.',
-    icon: '🎭',
     tests: [
       {
         title: 'Big Five',
@@ -85,7 +83,6 @@ export const categories: Category[] = [
     title: 'Implicit Association Tests',
     subtitle: 'Reaction-time based measures',
     description: 'Measure automatic associations through reaction time. Educational tools for exploring implicit cognition.',
-    icon: '⚡',
     tests: [
       {
         title: 'Flowers-Insects IAT',
@@ -104,7 +101,6 @@ export const categories: Category[] = [
     title: 'Empathy & Social Cognition',
     subtitle: 'Understanding others',
     description: 'Assess your ability to understand emotions, mental states, and social dynamics.',
-    icon: '👁️',
     tests: [
       {
         title: 'RMET',
@@ -123,7 +119,6 @@ export const categories: Category[] = [
     title: 'Values & Morality',
     subtitle: 'Ethical frameworks',
     description: 'Discover your moral intuitions and the values that guide your ethical decision-making.',
-    icon: '⚖️',
     tests: [
       {
         title: 'Moral Foundations',
@@ -142,7 +137,6 @@ export const categories: Category[] = [
     title: 'Cognitive',
     subtitle: 'Thinking patterns',
     description: 'Explore how you think, reason, and make decisions.',
-    icon: '🧠',
     tests: [
       {
         title: 'CRT',
@@ -161,7 +155,6 @@ export const categories: Category[] = [
     title: 'Relationships',
     subtitle: 'Connection patterns',
     description: 'Understand how you connect with others, express appreciation, and form attachments.',
-    icon: '💕',
     tests: [
       {
         title: 'Attachment Style',

--- a/frontend/pages/CategoryPage.tsx
+++ b/frontend/pages/CategoryPage.tsx
@@ -1,0 +1,126 @@
+import { Link, useParams } from 'react-router-dom';
+import { Layout } from '../components/Layout';
+import { getCategoryById, TestInfo } from '../data/test-categories';
+
+function RatingDots({ value, max = 5 }: { value: number; max?: number }) {
+  return (
+    <div className="flex gap-1">
+      {Array.from({ length: max }).map((_, i) => (
+        <div
+          key={i}
+          className={`w-1.5 h-1.5 rounded-full ${
+            i < value
+              ? 'bg-[var(--color-champagne)]'
+              : 'bg-[var(--color-border)]'
+          }`}
+        />
+      ))}
+    </div>
+  );
+}
+
+function TestCard({ test }: { test: TestInfo }) {
+  const href = test.link || `/test/${test.slug}`;
+  return (
+    <div className="card-premium rounded-lg p-8 group">
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex gap-6">
+          <div className="flex items-center gap-2">
+            <span className="text-[var(--color-text-muted)] text-[10px] tracking-wide uppercase">Seriousness</span>
+            <RatingDots value={test.seriousness} />
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-[var(--color-text-muted)] text-[10px] tracking-wide uppercase">Fun</span>
+            <RatingDots value={test.fun} />
+          </div>
+        </div>
+        <span className="text-[var(--color-text-muted)] text-xs tracking-wide">{test.time}</span>
+      </div>
+      <h4 className="font-display text-2xl font-medium text-[var(--color-text-primary)] mb-1 transition-colors duration-300">{test.title}</h4>
+      <p className="text-[var(--color-champagne)]/70 text-sm mb-4 tracking-wide">{test.subtitle}</p>
+      <p className="text-[var(--color-text-muted)] text-xs mb-3 tracking-wide">
+        {test.keywords.join(' · ')}
+      </p>
+      <p className="text-[var(--color-text-secondary)] text-sm mb-8 leading-relaxed transition-colors duration-300">{test.description}</p>
+      <Link
+        to={href}
+        className="btn-ghost block w-full py-3 rounded text-center text-xs tracking-widest uppercase"
+      >
+        Begin Assessment
+      </Link>
+    </div>
+  );
+}
+
+export function CategoryPage() {
+  const { categoryId } = useParams<{ categoryId: string }>();
+  const category = categoryId ? getCategoryById(categoryId) : undefined;
+
+  if (!category) {
+    return (
+      <Layout>
+        <main className="mx-auto max-w-6xl px-6 py-12">
+          <div className="text-center">
+            <h1 className="font-display text-4xl font-medium text-[var(--color-text-primary)] mb-4">
+              Category Not Found
+            </h1>
+            <Link to="/tests" className="text-[var(--color-champagne)] hover:underline">
+              Back to Tests
+            </Link>
+          </div>
+        </main>
+      </Layout>
+    );
+  }
+
+  return (
+    <Layout>
+      <main className="mx-auto max-w-6xl px-6 py-12">
+        {/* Breadcrumb */}
+        <nav className="mb-8">
+          <ol className="flex items-center gap-2 text-sm">
+            <li>
+              <Link
+                to="/tests"
+                className="text-[var(--color-text-muted)] hover:text-[var(--color-champagne)] transition-colors"
+              >
+                Tests
+              </Link>
+            </li>
+            <li className="text-[var(--color-text-muted)]">/</li>
+            <li className="text-[var(--color-text-primary)]">{category.title}</li>
+          </ol>
+        </nav>
+
+        {/* Header */}
+        <div className="text-center mb-16">
+          <div className="text-4xl mb-4">{category.icon}</div>
+          <p className="text-[var(--color-champagne)] text-xs tracking-[0.3em] uppercase mb-4">{category.subtitle}</p>
+          <h1 className="font-display text-4xl md:text-5xl font-medium text-[var(--color-text-primary)] transition-colors duration-300 mb-4">
+            {category.title}
+          </h1>
+          <p className="text-[var(--color-text-secondary)] max-w-2xl mx-auto leading-relaxed">
+            {category.description}
+          </p>
+        </div>
+
+        {/* Tests Grid */}
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
+          {category.tests.map((test) => (
+            <TestCard key={test.slug} test={test} />
+          ))}
+        </div>
+
+        {/* Back link */}
+        <div className="text-center mt-12">
+          <Link
+            to="/tests"
+            className="btn-ghost inline-block px-8 py-3 rounded text-xs tracking-widest uppercase"
+          >
+            ← All Categories
+          </Link>
+        </div>
+      </main>
+    </Layout>
+  );
+}

--- a/frontend/pages/CategoryPage.tsx
+++ b/frontend/pages/CategoryPage.tsx
@@ -36,8 +36,7 @@ function TestCard({ test }: { test: TestInfo }) {
         </div>
         <span className="text-[var(--color-text-muted)] text-xs tracking-wide">{test.time}</span>
       </div>
-      <h4 className="font-display text-2xl font-medium text-[var(--color-text-primary)] mb-1 transition-colors duration-300">{test.title}</h4>
-      <p className="text-[var(--color-champagne)]/70 text-sm mb-4 tracking-wide">{test.subtitle}</p>
+      <h4 className="font-display text-2xl font-medium text-[var(--color-text-primary)] mb-3 transition-colors duration-300">{test.title}</h4>
       <p className="text-[var(--color-text-muted)] text-xs mb-3 tracking-wide">
         {test.keywords.join(' · ')}
       </p>

--- a/frontend/pages/CategoryPage.tsx
+++ b/frontend/pages/CategoryPage.tsx
@@ -22,7 +22,7 @@ function RatingDots({ value, max = 5 }: { value: number; max?: number }) {
 function TestCard({ test }: { test: TestInfo }) {
   const href = test.link || `/test/${test.slug}`;
   return (
-    <div className="card-premium rounded-lg p-8 group">
+    <Link to={href} className="card-premium rounded-lg p-8 block hover:border-[var(--color-champagne)]/30 transition-colors">
       <div className="flex items-center justify-between mb-6">
         <div className="flex gap-6">
           <div className="flex items-center gap-2">
@@ -41,14 +41,8 @@ function TestCard({ test }: { test: TestInfo }) {
       <p className="text-[var(--color-text-muted)] text-xs mb-3 tracking-wide">
         {test.keywords.join(' · ')}
       </p>
-      <p className="text-[var(--color-text-secondary)] text-sm mb-8 leading-relaxed transition-colors duration-300">{test.description}</p>
-      <Link
-        to={href}
-        className="btn-ghost block w-full py-3 rounded text-center text-xs tracking-widest uppercase"
-      >
-        Begin Assessment
-      </Link>
-    </div>
+      <p className="text-[var(--color-text-secondary)] text-sm leading-relaxed transition-colors duration-300">{test.description}</p>
+    </Link>
   );
 }
 
@@ -94,8 +88,6 @@ export function CategoryPage() {
 
         {/* Header */}
         <div className="text-center mb-16">
-          <div className="text-4xl mb-4">{category.icon}</div>
-          <p className="text-[var(--color-champagne)] text-xs tracking-[0.3em] uppercase mb-4">{category.subtitle}</p>
           <h1 className="font-display text-4xl md:text-5xl font-medium text-[var(--color-text-primary)] transition-colors duration-300 mb-4">
             {category.title}
           </h1>

--- a/frontend/pages/TestsPage.tsx
+++ b/frontend/pages/TestsPage.tsx
@@ -6,29 +6,19 @@ import { useFeatureFlags } from '../contexts/FeatureFlagsContext';
 function CategoryCard({ category }: { category: Category }) {
   const testCount = category.tests.length;
   return (
-    <div className="card-premium rounded-lg p-8 group">
-      <div className="flex items-center justify-between mb-6">
-        <span className="text-4xl">{category.icon}</span>
+    <Link to={`/tests/${category.id}`} className="card-premium rounded-lg p-8 block hover:border-[var(--color-champagne)]/30 transition-colors">
+      <div className="mb-6">
         <span className="text-[var(--color-text-muted)] text-xs tracking-wide">
           {testCount} {testCount === 1 ? 'test' : 'tests'}
         </span>
       </div>
-      <h4 className="font-display text-2xl font-medium text-[var(--color-text-primary)] mb-1 transition-colors duration-300">
+      <h4 className="font-display text-2xl font-medium text-[var(--color-text-primary)] mb-4 transition-colors duration-300">
         {category.title}
       </h4>
-      <p className="text-[var(--color-champagne)]/70 text-sm mb-4 tracking-wide">
-        {category.subtitle}
-      </p>
-      <p className="text-[var(--color-text-secondary)] text-sm mb-8 leading-relaxed transition-colors duration-300">
+      <p className="text-[var(--color-text-secondary)] text-sm leading-relaxed transition-colors duration-300">
         {category.description}
       </p>
-      <Link
-        to={`/tests/${category.id}`}
-        className="btn-ghost block w-full py-3 rounded text-center text-xs tracking-widest uppercase"
-      >
-        Explore Category
-      </Link>
-    </div>
+    </Link>
   );
 }
 

--- a/frontend/pages/TestsPage.tsx
+++ b/frontend/pages/TestsPage.tsx
@@ -1,6 +1,36 @@
 import { Link } from 'react-router-dom';
 import { Layout } from '../components/Layout';
+import { categories, Category } from '../data/test-categories';
 import { useFeatureFlags } from '../contexts/FeatureFlagsContext';
+
+function CategoryCard({ category }: { category: Category }) {
+  const testCount = category.tests.length;
+  return (
+    <div className="card-premium rounded-lg p-8 group">
+      <div className="flex items-center justify-between mb-6">
+        <span className="text-4xl">{category.icon}</span>
+        <span className="text-[var(--color-text-muted)] text-xs tracking-wide">
+          {testCount} {testCount === 1 ? 'test' : 'tests'}
+        </span>
+      </div>
+      <h4 className="font-display text-2xl font-medium text-[var(--color-text-primary)] mb-1 transition-colors duration-300">
+        {category.title}
+      </h4>
+      <p className="text-[var(--color-champagne)]/70 text-sm mb-4 tracking-wide">
+        {category.subtitle}
+      </p>
+      <p className="text-[var(--color-text-secondary)] text-sm mb-8 leading-relaxed transition-colors duration-300">
+        {category.description}
+      </p>
+      <Link
+        to={`/tests/${category.id}`}
+        className="btn-ghost block w-full py-3 rounded text-center text-xs tracking-widest uppercase"
+      >
+        Explore Category
+      </Link>
+    </div>
+  );
+}
 
 function RatingDots({ value, max = 5 }: { value: number; max?: number }) {
   return (
@@ -19,51 +49,32 @@ function RatingDots({ value, max = 5 }: { value: number; max?: number }) {
   );
 }
 
-function TestCard({
-  title,
-  subtitle,
-  slug,
-  keywords,
-  description,
-  time,
-  seriousness,
-  fun,
-  link,
-}: {
-  title: string;
-  subtitle: string;
-  slug: string;
-  keywords: string[];
-  description: string;
-  time: string;
-  seriousness: number;
-  fun: number;
-  link?: string;
-}) {
-  const href = link || `/test/${slug}`;
+function MiniTestCard() {
   return (
     <div className="card-premium rounded-lg p-8 group">
       <div className="flex items-center justify-between mb-6">
         <div className="flex gap-6">
           <div className="flex items-center gap-2">
             <span className="text-[var(--color-text-muted)] text-[10px] tracking-wide uppercase">Seriousness</span>
-            <RatingDots value={seriousness} />
+            <RatingDots value={1} />
           </div>
           <div className="flex items-center gap-2">
             <span className="text-[var(--color-text-muted)] text-[10px] tracking-wide uppercase">Fun</span>
-            <RatingDots value={fun} />
+            <RatingDots value={1} />
           </div>
         </div>
-        <span className="text-[var(--color-text-muted)] text-xs tracking-wide">{time}</span>
+        <span className="text-[var(--color-text-muted)] text-xs tracking-wide">1 min</span>
       </div>
-      <h4 className="font-display text-2xl font-medium text-[var(--color-text-primary)] mb-1 transition-colors duration-300">{title}</h4>
-      <p className="text-[var(--color-champagne)]/70 text-sm mb-4 tracking-wide">{subtitle}</p>
+      <h4 className="font-display text-2xl font-medium text-[var(--color-text-primary)] mb-1 transition-colors duration-300">Mini-Test</h4>
+      <p className="text-[var(--color-champagne)]/70 text-sm mb-4 tracking-wide">5 Questions</p>
       <p className="text-[var(--color-text-muted)] text-xs mb-3 tracking-wide">
-        {keywords.join(' · ')}
+        Debug · Testing · Quick
       </p>
-      <p className="text-[var(--color-text-secondary)] text-sm mb-8 leading-relaxed transition-colors duration-300">{description}</p>
+      <p className="text-[var(--color-text-secondary)] text-sm mb-8 leading-relaxed transition-colors duration-300">
+        A 5-question sampler for debugging and automated testing. One question from each Big Five dimension.
+      </p>
       <Link
-        to={href}
+        to="/test/mini-test"
         className="btn-ghost block w-full py-3 rounded text-center text-xs tracking-widest uppercase"
       >
         Begin Assessment
@@ -84,136 +95,16 @@ export function TestsPage() {
             Explore Tests
           </h1>
           <p className="text-[var(--color-text-secondary)] max-w-2xl mx-auto leading-relaxed">
-            Each test is rated on two dimensions: Seriousness reflects the depth of research
-            supporting its validity, while Fun captures how engaging the experience is.
+            Browse our collection of personality assessments organized by category.
+            Each test is rated on Seriousness (research validity) and Fun (engagement).
           </p>
         </div>
 
-        {/* Primary Tests - High scientific validity */}
-        <div className="grid md:grid-cols-3 gap-8">
-          <TestCard
-            title="Big Five"
-            subtitle="IPIP-NEO"
-            slug="big-five"
-            keywords={['Traits', 'Behavior', 'Stability']}
-            description="The gold standard in personality psychology. Measures Openness, Conscientiousness, Extraversion, Agreeableness, and Neuroticism."
-            time="15 min"
-            seriousness={5}
-            fun={3}
-          />
-          <TestCard
-            title="HEXACO"
-            subtitle="Six Dimensions"
-            slug="hexaco"
-            link="/hexaco"
-            keywords={['Ethics', 'Honesty', 'Integrity']}
-            description="Six-factor model including Honesty-Humility. Predicts ethical behavior and workplace conduct with precision."
-            time="12 min"
-            seriousness={5}
-            fun={2}
-          />
-          <TestCard
-            title="Attachment Style"
-            subtitle="ECR-RS"
-            slug="ecr"
-            keywords={['Relationships', 'Anxiety', 'Avoidance']}
-            description="Understand your attachment patterns in close relationships. Measures anxiety and avoidance on continuous dimensions."
-            time="5 min"
-            seriousness={5}
-            fun={4}
-          />
-        </div>
-
-        {/* Second Row */}
-        <div className="grid md:grid-cols-3 gap-8 mt-8">
-          <TestCard
-            title="Moral Foundations"
-            subtitle="MFQ-30"
-            slug="mfq"
-            keywords={['Ethics', 'Values', 'Politics']}
-            description="Discover your moral intuitions across five foundations: Care, Fairness, Loyalty, Authority, and Purity. Based on Jonathan Haidt's research."
-            time="10 min"
-            seriousness={4}
-            fun={4}
-          />
-          <TestCard
-            title="Dark Triad"
-            subtitle="SD3"
-            slug="sd3"
-            keywords={['Strategy', 'Confidence', 'Boldness']}
-            description="Measures subclinical Machiavellianism, Narcissism, and Psychopathy. High engagement due to 'forbidden' appeal."
-            time="5 min"
-            seriousness={4}
-            fun={5}
-          />
-          <TestCard
-            title="CRT"
-            subtitle="Cognitive Reflection"
-            slug="crt"
-            keywords={['Reasoning', 'Reflection', 'Intuition']}
-            description="Test your ability to override intuitive wrong answers through deliberate reflection. The famous 'bat and ball' problem and more."
-            time="5 min"
-            seriousness={4}
-            fun={5}
-          />
-        </div>
-
-        {/* Third Row */}
-        <div className="grid md:grid-cols-3 gap-8 mt-8">
-          <TestCard
-            title="RMET"
-            subtitle="Eyes Test"
-            slug="rmet"
-            keywords={['Social Cognition', 'Empathy', 'Theory of Mind']}
-            description="Measure your ability to recognize emotions and mental states from eye expressions. Research-backed assessment of social cognition."
-            time="10 min"
-            seriousness={4}
-            fun={4}
-          />
-          <TestCard
-            title="Myers-Briggs"
-            subtitle="OEJTS"
-            slug="mbti"
-            keywords={['Types', 'Cognitive', 'Popular']}
-            description="The world's most popular personality test. Discover your type across four dichotomies: E/I, S/N, T/F, J/P."
-            time="10 min"
-            seriousness={2}
-            fun={5}
-          />
-          <TestCard
-            title="Enneagram"
-            subtitle="Nine Types"
-            slug="enneagram"
-            keywords={['Motivations', 'Growth', 'Archetypes']}
-            description="Explore your core motivations through nine distinct personality archetypes. Renowned for personal growth insights."
-            time="10 min"
-            seriousness={2}
-            fun={5}
-          />
-        </div>
-
-        {/* Fourth Row */}
-        <div className="grid md:grid-cols-3 gap-8 mt-8">
-          <TestCard
-            title="Communication Styles"
-            subtitle="Five Styles"
-            slug="communication-styles"
-            keywords={['Relationships', 'Appreciation', 'Connection']}
-            description="Discover how you prefer to give and receive appreciation. Learn your primary style for deeper connections."
-            time="5 min"
-            seriousness={2}
-            fun={5}
-          />
-          <TestCard
-            title="IAT"
-            subtitle="Implicit Association Test"
-            slug="iat"
-            keywords={['Reaction Time', 'Automatic Associations', 'Self-Reflection']}
-            description="Measure automatic associations through reaction time. Educational tool for exploring implicit cognition. Low individual reliability."
-            time="5-10 min"
-            seriousness={3}
-            fun={4}
-          />
+        {/* Category Cards Grid */}
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
+          {categories.map((category) => (
+            <CategoryCard key={category.id} category={category} />
+          ))}
         </div>
 
         {/* Mini-Test - Admin/Test Users Only */}
@@ -225,16 +116,7 @@ export function TestsPage() {
               </span>
             </div>
             <div className="max-w-md mx-auto">
-              <TestCard
-                title="Mini-Test"
-                subtitle="5 Questions"
-                slug="mini-test"
-                keywords={['Debug', 'Testing', 'Quick']}
-                description="A 5-question sampler for debugging and automated testing. One question from each Big Five dimension."
-                time="1 min"
-                seriousness={1}
-                fun={1}
-              />
+              <MiniTestCard />
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary

- Restructures the Tests page to organize assessments into 6 categories
- Each category card leads to a dedicated category page with breadcrumb navigation
- Categories: Personality, IAT, Empathy & Social Cognition, Values & Morality, Cognitive, Relationships
- All existing tests remain accessible through their respective categories

## Test plan

- [x] Tests page shows 6 category cards
- [x] Category pages list tests with proper navigation
- [x] Breadcrumb navigation works correctly
- [x] All 93 e2e tests pass locally
- [ ] GitHub Actions E2E check passes

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)